### PR TITLE
bump version to 0.3.1; add skip-existing to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,3 +39,5 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true   # silently skip if this version already exists on PyPI

--- a/foureng/__init__.py
+++ b/foureng/__init__.py
@@ -24,7 +24,7 @@ live at ``foureng.char_func`` before the Pass-1 PyFENG-compat rename.
 """
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .models.base import ForwardSpec, CharFunc, ModelSpec
 from .models.heston import HestonParams, heston_cf_form2, heston_cumulants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fourier-option-pricer"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fourier-based European option pricing with Carr-Madan FFT, FRFT, and COS under characteristic-function models."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
v0.3.0 was already manually uploaded via twine before the GitHub Actions Trusted Publisher workflow ran, causing the deployment to fail with a duplicate-file error.  Bump to 0.3.1 so the next tagged release lands a version PyPI hasn't seen.

Also add skip-existing: true to pypa/gh-action-pypi-publish as a permanent safety net against accidental re-deploys.