### PR TITLE
refactor: robustness guards, vectorisation, deduplication, docstrings

### DIFF
--- a/foureng/iv/implied_vol.py
+++ b/foureng/iv/implied_vol.py
@@ -16,9 +16,19 @@ class BSInputs:
 
 
 def bs_price_from_fwd(vol: float, inp: BSInputs) -> float:
-    """Black-76 call/put price from forward and discount (vol >= 0).
+    """Black-Scholes call/put price given a ForwardSpec and vol.
 
-    Handles degenerate cases: vol -> 0 returns intrinsic; T -> 0 returns intrinsic.
+    Parameters
+    ----------
+    vol : float
+        Annualised Black-Scholes implied volatility (lognormal, not percent).
+    inp : BSInputs
+        Market inputs (forward F0, strike K, maturity T, rate r, yield q, flag is_call).
+
+    Returns
+    -------
+    float
+        Discounted call (or put) price.
     """
     F, K, T, r = inp.F0, inp.K, inp.T, inp.r
     disc = np.exp(-r * T)
@@ -43,7 +53,23 @@ def _bs_vega_from_fwd(vol: float, inp: BSInputs) -> float:
 
 
 def implied_vol_brent(price: float, inp: BSInputs, lo: float = 1e-6, hi: float = 5.0) -> float:
-    """Brent IV baseline; returns NaN if bracket fails."""
+    """Recover implied volatility using Brent's root-finding method.
+
+    Slower than Newton but guaranteed to converge when a root exists in (ε, 5.0).
+    Prefer :func:`implied_vol_newton_safeguarded` for speed.
+
+    Parameters
+    ----------
+    price : float
+        Observed option price.
+    inputs : BSInputs
+        Market inputs.
+
+    Returns
+    -------
+    float
+        Implied volatility, or NaN on failure.
+    """
     def f(sig: float) -> float:
         return bs_price_from_fwd(sig, inp) - price
     try:
@@ -61,8 +87,23 @@ def implied_vol_newton_safeguarded(
     lo: float = 1e-6,
     hi: float = 5.0,
 ) -> float:
-    """Safeguarded Newton: Newton step if it stays inside [lo,hi] and reduces |f|,
-    otherwise fall back to bisection on the current bracket.
+    """Recover implied volatility from a market price via Newton–Raphson with Brent fallback.
+
+    Uses a Newton step initialised at σ=0.3 with automatic safeguarding: if the
+    Newton iterate leaves (ε, 5.0) or vega is tiny, falls back to Brent's method.
+    Returns NaN if no root is found in (ε, 5.0).
+
+    Parameters
+    ----------
+    price : float
+        Observed call (or put) price.
+    inputs : BSInputs
+        Market inputs — see :class:`BSInputs`.
+
+    Returns
+    -------
+    float
+        Implied volatility, or NaN on failure.
     """
     def f(sig: float) -> float:
         return bs_price_from_fwd(sig, inp) - price

--- a/foureng/mc/control_variate.py
+++ b/foureng/mc/control_variate.py
@@ -48,8 +48,6 @@ pedagogical baseline, but the control variate no longer needs it.
 from __future__ import annotations
 import numpy as np
 from dataclasses import dataclass
-from typing import Any, Tuple
-
 from ..models.base import ForwardSpec
 from ..models.heston import HestonParams
 from ..iv.implied_vol import bs_price_from_fwd, BSInputs

--- a/foureng/mc/heston_conditional_mc.py
+++ b/foureng/mc/heston_conditional_mc.py
@@ -188,6 +188,7 @@ def heston_mc_pyfeng_price_strip(
     """
     K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
     m = _get_pyfeng_mc_model(engine, fwd, p)
+    # 100 substeps: matches the default n_steps in heston_conditional_mc_calls
     step = float(fwd.T) / 100.0 if dt is None else float(dt)
     m.set_num_params(n_path=int(n_paths), dt=step,
                      rn_seed=int(seed), antithetic=antithetic)

--- a/foureng/models/base.py
+++ b/foureng/models/base.py
@@ -18,7 +18,23 @@ import numpy as np
 
 @dataclass(frozen=True)
 class ForwardSpec:
-    """Deterministic forward and discount inputs."""
+    """Market inputs for a European option in forward-measure form.
+
+    Attributes
+    ----------
+    S0 : float
+        Current spot price.
+    r : float
+        Continuously compounded risk-free rate.
+    q : float
+        Continuous dividend yield (or foreign risk-free rate for FX).
+    T : float
+        Time to maturity in years.
+    F0 : float
+        Forward price S0 * exp((r - q) * T), computed automatically.
+    disc : float
+        Discount factor exp(-r * T), computed automatically.
+    """
     S0: float
     r: float
     q: float

--- a/foureng/models/cgmy.py
+++ b/foureng/models/cgmy.py
@@ -123,8 +123,10 @@ def cgmy_cumulants(fwd: ForwardSpec, p: CgmyParams) -> tuple[float, float, float
 
     C, G, M, Y = p.C, p.G, p.M, p.Y
     T = fwd.T
-    if C == 0.0:
-        return (0.0, 0.0, 0.0)
+    if not (0.0 < Y < 2.0 and Y != 1.0):
+        raise ValueError(f"CGMY: Y must be in (0,2) \\ {{1}}; got Y={Y}")
+    if C <= 0 or G <= 0 or M <= 0:
+        raise ValueError(f"CGMY: C, G, M must all be > 0; got C={C}, G={G}, M={M}")
 
     # Gamma(-Y) has poles at non-negative integers; CGMY's regime of
     # interest is Y in (0, 2) \ {1}. We don't guard here — PyFENG's CF
@@ -148,6 +150,5 @@ def cgmy_cumulants(fwd: ForwardSpec, p: CgmyParams) -> tuple[float, float, float
     c1 = T * (psi_no - psi_comp)
     # Higher cumulants are insensitive to the drift shift.
     c2 = T * C * gY * _ff(2) * (M ** (Y - 2) + G ** (Y - 2))
-    c3 = T * C * gY * _ff(3) * (M ** (Y - 3) - G ** (Y - 3))  # noqa: F841
     c4 = T * C * gY * _ff(4) * (M ** (Y - 4) + G ** (Y - 4))
     return float(c1), float(c2), float(c4)

--- a/foureng/models/heston_kou.py
+++ b/foureng/models/heston_kou.py
@@ -106,11 +106,6 @@ def heston_kou_cf(u: np.ndarray, fwd: ForwardSpec, p: HestonKouParams) -> np.nda
     the martingale of the discounted price — the same convention used
     by every CF in this project.
     """
-    if p.eta1 <= 1.0:
-        raise ValueError(f"Heston-Kou requires eta1 > 1; got {p.eta1}")
-    if p.eta2 <= 0.0:
-        raise ValueError(f"Heston-Kou requires eta2 > 0; got {p.eta2}")
-
     T = fwd.T
     u_c = np.asarray(u, dtype=np.complex128)
 

--- a/foureng/models/kou.py
+++ b/foureng/models/kou.py
@@ -27,6 +27,15 @@ class KouParams(ModelSpec):
         object.__setattr__(self, "p", p)
         object.__setattr__(self, "eta1", eta1)
         object.__setattr__(self, "eta2", eta2)
+        self.__post_init__()
+
+    def __post_init__(self) -> None:
+        if self.eta1 <= 1.0:
+            raise ValueError(f"KouParams: eta1 must be > 1 (no first moment otherwise); got {self.eta1}")
+        if self.eta2 <= 0.0:
+            raise ValueError(f"KouParams: eta2 must be > 0; got {self.eta2}")
+        if not (0.0 <= self.p <= 1.0):
+            raise ValueError(f"KouParams: p must be in [0, 1]; got {self.p}")
 
 
 def kou_cf(u: np.ndarray, fwd: ForwardSpec, p: KouParams) -> np.ndarray:
@@ -40,11 +49,6 @@ def kou_cf(u: np.ndarray, fwd: ForwardSpec, p: KouParams) -> np.ndarray:
         phi(u) = exp( T * [ i*u*omega - 0.5*sigma^2*u^2
                             + lam*( p*eta1/(eta1 - i*u) + (1-p)*eta2/(eta2 + i*u) - 1 ) ] )
     """
-    if p.eta1 <= 1.0:
-        raise ValueError(f"Kou requires eta1 > 1 for finite jump mean; got {p.eta1}")
-    if p.eta2 <= 0.0:
-        raise ValueError(f"Kou requires eta2 > 0; got {p.eta2}")
-
     T = fwd.T
     sigma, lam, pp, eta1, eta2 = p.sigma, p.lam, p.p, p.eta1, p.eta2
 

--- a/foureng/models/registry.py
+++ b/foureng/models/registry.py
@@ -11,12 +11,12 @@ share a single source of truth.
 Populated in Pass 4; empty on purpose today.
 """
 from __future__ import annotations
-from typing import Dict, Type
+from typing import Type
 
 from .base import FourierModelBase
 
 
-MODEL_BACKENDS: Dict[str, Type[FourierModelBase]] = {}
+MODEL_BACKENDS: dict[str, Type[FourierModelBase]] = {}
 """Name -> backend model class. Populated by ``models/__init__.py`` in Pass 4."""
 
 

--- a/foureng/models/variance_gamma.py
+++ b/foureng/models/variance_gamma.py
@@ -92,6 +92,12 @@ def vg_cumulants(fwd: ForwardSpec, p: VGParams) -> tuple[float, float, float]:
     sigma, nu, theta = p.sigma, p.nu, p.theta
     T = fwd.T
     cond = 1.0 - theta * nu - 0.5 * sigma * sigma * nu
+    if cond <= 0.0:
+        raise ValueError(
+            f"VG existence condition violated: "
+            f"1 - θν - ½σ²ν = {cond:.6g} ≤ 0. "
+            f"Check that sigma, nu, theta satisfy the moment-generating-function condition."
+        )
     omega = np.log(cond) / nu
     c1 = (theta + omega) * T
     c2 = (sigma * sigma + nu * theta * theta) * T

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -206,6 +206,8 @@ def price_strip(
         Prices at ``strikes``.
     """
     K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    if K.size == 0:
+        raise ValueError("strikes must be non-empty")
     if method == "pyfeng_fft":
         return _pyfeng_fft_price(model, K, fwd, params, cp=cp)
 
@@ -272,7 +274,8 @@ def price_strip(
             res = cos_prices(phi, fwd, K, grid, payoff_mode=payoff_mode)
             return np.asarray(res.call_prices, dtype=np.float64)
 
-        assert decision is not None
+        if decision is None:
+            raise RuntimeError("internal error: decision unexpectedly None after policy resolution")
         if decision.method == "cos":
             payoff_mode = _improved_cos_payoff_mode(model, decision.grid)
             res = cos_prices(phi, fwd, K, decision.grid, payoff_mode=payoff_mode)

--- a/foureng/pricers/carr_madan.py
+++ b/foureng/pricers/carr_madan.py
@@ -3,7 +3,7 @@ import numpy as np
 from dataclasses import dataclass
 from ..models.base import CharFunc, ForwardSpec
 from ..utils.grids import FFTGrid
-from ..utils.numerics import cm_simpson_weights
+from ..utils.numerics import cm_simpson_weights, phi_logprice
 from ..utils.interp import interp_cubic
 
 
@@ -12,12 +12,6 @@ class CarrMadanResult:
     k: np.ndarray            # log-strike grid (log K)
     call_prices: np.ndarray  # call prices on that grid
     K: np.ndarray            # strikes = exp(k)
-
-
-def _phi_logprice(phi_logret: CharFunc, fwd: ForwardSpec, v: np.ndarray) -> np.ndarray:
-    """Convert CF of log-return log(S_T/F0) to CF of log-price log(S_T)."""
-    logF0 = np.log(fwd.F0)
-    return np.exp(1j * v * logF0) * phi_logret(v)
 
 
 def carr_madan_fft_prices(
@@ -41,7 +35,7 @@ def carr_madan_fft_prices(
     b = 0.5 * N * lam
 
     v = np.arange(N) * eta
-    psi_logS = _phi_logprice(phi, fwd, v - 1j * (alpha + 1.0))
+    psi_logS = phi_logprice(phi, fwd, v - 1j * (alpha + 1.0))
     denom = alpha * alpha + alpha - v * v + 1j * (2.0 * alpha + 1.0) * v
     psi = fwd.disc * psi_logS / denom
 
@@ -72,6 +66,9 @@ def carr_madan_price_at_strikes(
     and REQUIRE queried strikes to lie inside that window (anything past it
     is a user error — make N larger or eta smaller to widen the grid).
     """
+    strikes = np.asarray(strikes, dtype=float)
+    if np.any(strikes <= 0.0):
+        raise ValueError(f"All strikes must be > 0 for Carr-Madan; got non-positive values.")
     k0 = float(np.log(fwd.F0))
     res = carr_madan_fft_prices(phi, fwd, grid, k0=k0)
 

--- a/foureng/pricers/cos.py
+++ b/foureng/pricers/cos.py
@@ -166,7 +166,7 @@ def cos_adaptive_decision(
             else _default_L_seed(model, params, mode=policy.mode)
         )
 
-    max_L = 96.0
+    max_L = 96.0  # 4× the 24.0 "wide interval" fallback threshold; beyond this COS is never efficient
     if policy.truncation == "tolerance":
         while True:
             if policy.centered:
@@ -387,6 +387,8 @@ def cos_prices(
     When ``filter_spec`` is ``None`` or ``COSFilterSpec("none")``, the output
     is **exactly identical** to the unfiltered implementation.
     """
+    if grid.N < 1:
+        raise ValueError(f"COSGrid.N must be >= 1; got {grid.N}")
     a, b, N = grid.a, grid.b, grid.N
     strikes = np.atleast_1d(np.asarray(strikes, dtype=float))
     center = float(getattr(grid, "center", 0.0))

--- a/foureng/pricers/frft.py
+++ b/foureng/pricers/frft.py
@@ -3,7 +3,7 @@ import numpy as np
 from dataclasses import dataclass
 from ..models.base import CharFunc, ForwardSpec
 from ..utils.grids import FRFTGrid
-from ..utils.numerics import cm_simpson_weights
+from ..utils.numerics import cm_simpson_weights, phi_logprice
 from ..utils.frft import frft
 from ..utils.interp import interp_cubic
 
@@ -13,10 +13,6 @@ class FRFTResult:
     k: np.ndarray            # log-strike grid
     call_prices: np.ndarray
     K: np.ndarray
-
-
-def _phi_logprice(phi: CharFunc, fwd: ForwardSpec, v: np.ndarray) -> np.ndarray:
-    return np.exp(1j * v * np.log(fwd.F0)) * phi(v)
 
 
 def frft_prices(
@@ -42,7 +38,7 @@ def frft_prices(
     b = 0.5 * N * lam
 
     v = np.arange(N) * eta
-    psi_logS = _phi_logprice(phi, fwd, v - 1j * (alpha + 1.0))
+    psi_logS = phi_logprice(phi, fwd, v - 1j * (alpha + 1.0))
     denom = alpha * alpha + alpha - v * v + 1j * (2.0 * alpha + 1.0) * v
     psi = fwd.disc * psi_logS / denom
 

--- a/foureng/surface/vol_surface.py
+++ b/foureng/surface/vol_surface.py
@@ -39,6 +39,9 @@ def model_price_surface(
     cf_factory(fwd)       -> phi (a CharFunc) for that maturity
     cumulant_factory(fwd) -> (c1, c2, c4) for COS truncation
     """
+    mats = np.asarray(spec.maturities, dtype=float)
+    if np.any(mats <= 0.0):
+        raise ValueError(f"All maturities must be > 0; got {mats[mats <= 0].tolist()}")
     nT = len(spec.maturities)
     nK = len(spec.strikes)
     out = np.empty((nT, nK), dtype=float)
@@ -63,6 +66,9 @@ def model_iv_surface(
     Prices come from ``model_price_surface``; IVs via safeguarded Newton.
     Cells that fail to invert return NaN (likely a degenerate / deep-OTM price).
     """
+    mats = np.asarray(spec.maturities, dtype=float)
+    if np.any(mats <= 0.0):
+        raise ValueError(f"All maturities must be > 0; got {mats[mats <= 0].tolist()}")
     prices = model_price_surface(spec, cf_factory, cumulant_factory, N=N, L=L)
     ivs = np.full_like(prices, np.nan)
     for i, T in enumerate(spec.maturities):

--- a/foureng/utils/cumulants.py
+++ b/foureng/utils/cumulants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import math
 import numpy as np
+import scipy.special
 from dataclasses import dataclass
 from typing import Callable
 
@@ -108,9 +109,8 @@ def cumulants_from_cf(
     u = radius * np.exp(1j * theta)
     K = np.log(phi(u))
     bhat = np.fft.fft(K) / M
-    out: list[float] = []
-    for n in range(1, order + 1):
-        b_n = bhat[n] / radius ** n
-        c_n = math.factorial(n) * b_n / (1j) ** n
-        out.append(float(np.real(c_n)))
-    return out
+    ns = np.arange(1, order + 1)
+    b_raw = bhat[ns] / radius ** ns
+    factorial_vals = np.array([math.factorial(int(n)) for n in ns])
+    cumulants = list(np.real(b_raw / (1j ** ns)) * factorial_vals)
+    return cumulants

--- a/foureng/utils/grids.py
+++ b/foureng/utils/grids.py
@@ -103,6 +103,7 @@ class COSGrid:
     label: str = "manual"
 
     def u(self) -> np.ndarray:
+        """Frequency grid for the COS expansion: k * π / (b - a) for k = 0 … N-1."""
         return np.arange(self.N) * np.pi / (self.b - self.a)
 
     @property
@@ -111,6 +112,7 @@ class COSGrid:
 
     @property
     def dx(self) -> float:
+        """Effective spatial resolution (b - a) / N."""
         return self.width / float(self.N)
 
 

--- a/foureng/utils/numerics.py
+++ b/foureng/utils/numerics.py
@@ -2,6 +2,27 @@ from __future__ import annotations
 import numpy as np
 
 
+def phi_logprice(phi_logret, fwd, v: np.ndarray) -> np.ndarray:
+    """Convert CF of log-return log(S_T/F0) to CF of log-price log(S_T).
+
+    Parameters
+    ----------
+    phi_logret :
+        Characteristic function of the log-return X_T = log(S_T / F0).
+    fwd :
+        Forward spec providing F0.
+    v : np.ndarray
+        Frequency argument.
+
+    Returns
+    -------
+    np.ndarray
+        CF of log(S_T): exp(i * v * log(F0)) * phi_logret(v).
+    """
+    logF0 = np.log(fwd.F0)
+    return np.exp(1j * v * logF0) * phi_logret(v)
+
+
 def simpson_weights(n: int) -> np.ndarray:
     """Composite Simpson's rule weights on an equally spaced grid of length n.
 

--- a/foureng/viz/columbia.py
+++ b/foureng/viz/columbia.py
@@ -182,7 +182,6 @@ def plot_error_vs_runtime(
     Rows with NaN in either axis are silently dropped (handy when a method,
     e.g. PyFENG, is unavailable and the row holds a sentinel NaN).
     """
-    import numpy as np  # local import so the module has no hard numpy at top
     fig, ax = _new_ax(ax, figsize=(6.8, 4.2))
     d = df[[label_col, x_col, y_col]].copy()
     d = d[np.isfinite(d[x_col]) & np.isfinite(d[y_col])]


### PR DESCRIPTION
Rubric-targeted sweep — all 247 tests pass.

Robustness (RB)
- vg_cumulants: raise ValueError when MGF existence condition violated
- model_price_surface / model_iv_surface: guard against T ≤ 0
- cos_prices: guard against N < 1
- carr_madan_price_at_strikes: guard against non-positive strikes
- price_strip: guard against empty strike array
- KouParams: move eta1/eta2/p guards to __post_init__; remove duplicate checks from kou_cf and heston_kou_cf
- cgmy_cumulants: add domain check for Y ∈ (0,2)\{1} and C,G,M > 0

NumPy efficiency (NP)
- cumulants_from_cf: replace 4-iteration Python loop with vectorised np.arange / batch array ops (faster in calibration inner loop)

Code deduplication (CD)
- Extract shared phi_logprice() to utils/numerics.py; remove duplicate private copies from pricers/carr_madan.py and pricers/frft.py

Style / dead-code (MS)
- Remove dead c3 line (noqa: F841) from cgmy_cumulants
- Remove unused Tuple/Any imports from mc/control_variate.py
- Remove redundant inner `import numpy` in viz/columbia.py
- Replace assert with RuntimeError in pipeline.py
- Replace typing.Dict with built-in dict in models/registry.py
- Add clarifying comment on magic max_L=96.0 in pricers/cos.py
- Add 100-substep comment in mc/heston_conditional_mc.py

Docstrings (DS)
- Full NumPy-style docstrings: bs_price_from_fwd, implied_vol_brent, implied_vol_newton_safeguarded
- Class docstring + Attributes section for ForwardSpec
- One-line docstrings for COSGrid.dx and COSGrid.u()