### PR TITLE
docs: link notebooks from documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 Reference documentation for the `foureng` / `fourier-option-pricer` package.
 Start at [README.md](../README.md) for the project overview; come here for depth.
+For runnable walkthroughs, pair this index with the notebooks in [`notebooks/`](../notebooks/).
 
 ---
 


### PR DESCRIPTION
Adds a small pointer from the documentation index to the runnable notebooks.\n\nCo-authored-by: Stella-HYT <276826147+Stella-HYT@users.noreply.github.com>