### PR TITLE
Add CONV and BSM finite-difference pricers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ where $c_1, c_2, c_4$ are the model's cumulants and $L$ is a heuristic multiplie
 
 This project implements the **improved COS truncation** of Junike & Pankrashkin (2022) and Junike (2024), which replaces the heuristic $L$ with a rigorous tail-mass bound. On the FO2008 test suite, this truncation improvement beats the paper-grid COS in 7 of 8 cases and beats the paper's own best-N result in 6 of 8 (see [`benchmarks/cos_method_improved/`](benchmarks/cos_method_improved/outputs/cos_method_improved_paper_compare.csv)). On top of that, we add an **original adaptive filtered-COS extension**: spectral weights $\sigma_k \in [0, 1]$ (Fejér, Lanczos, raised-cosine, or exponential) applied to the high-frequency COS coefficients to suppress residual oscillation from sharp density features. A policy-search selector automatically compares grid and filter combinations, returning the fastest configuration that meets the user's tolerance, with the plain Junike path always included as a fallback.
 
-The package covers **20 models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, all priced through one `price_strip` dispatcher with **6 interchangeable engines**.
+The package covers **20 models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, all priced through one `price_strip` dispatcher with **7 characteristic-function engines** plus BSM finite-difference and lattice baselines.
 
 Full methodology: [appendix.md](appendix.md) · Extension details: [docs/filtered_cos_extension.md](docs/filtered_cos_extension.md) · Package architecture: [docs/architecture_overview.md](docs/architecture_overview.md).
 
@@ -206,7 +206,7 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 |----------|------------|---------|
 | `price_strip(model, method, strikes, fwd, params, grid=None)` | model label, method label, strike array, `ForwardSpec`, model params, optional grid | `np.ndarray` of call prices |
 
-Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"pyfeng_fft"`.
+Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` and `"lattice"`.
 
 ### Core pricing functions
 
@@ -215,7 +215,10 @@ Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"fr
 | `cos_prices(phi, fwd, strikes, grid)` | characteristic function, `ForwardSpec`, strike array, `COSGrid` | `COSResult` with `.call_prices` |
 | `carr_madan_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FFTGrid`, strike array | `np.ndarray` |
 | `frft_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FRFTGrid`, strike array | `np.ndarray` |
+| `conv_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `CONVGrid`, strike array | `np.ndarray` |
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=None)` | CF, `ForwardSpec`, strike array, `COSGrid`, optional `COSFilterSpec` | `COSResult` |
+| `bsm_lattice_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `LatticeGrid`, strike array | `np.ndarray` |
+| `bsm_pde_fd_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `PDEGrid`, strike array | `np.ndarray` |
 
 ### Grid constructors
 
@@ -225,6 +228,9 @@ Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"fr
 | `cos_improved_grid(cumulants, model, params)` | cumulants, model name, params | `COSGrid` via Junike truncation policy |
 | `FFTGrid(N, eta, alpha)` | FFT size, frequency spacing, damping factor | Carr-Madan FFT grid |
 | `FRFTGrid(N, eta, lam, alpha)` | size, freq spacing, strike step, damping | FRFT grid |
+| `CONVGrid(N, u_max)` | positive-frequency node count and cutoff | CONV-style Fourier inversion grid |
+| `LatticeGrid(steps)` | tree step count | BSM CRR lattice grid |
+| `PDEGrid(spot_steps, time_steps, s_max_mult)` | finite-difference grid controls | BSM implicit finite-difference grid |
 
 ### Implied volatility and Greeks
 
@@ -252,7 +258,7 @@ MIT. See [LICENSE](LICENSE).
 
 ### Supplementary notebook
 
-[`notebooks/supplementary/demo_advanced.ipynb`](notebooks/supplementary/demo_advanced.ipynb) is a **supplementary reference** for readers who want a comprehensive tour after the main demo. It covers all 20 models, all 6 pricers, Greeks, IV surface, Heston calibration, Monte Carlo, new models (Double Heston, VGSA), and validation highlights. It is **not** the recommended starting point.
+[`notebooks/supplementary/demo_advanced.ipynb`](notebooks/supplementary/demo_advanced.ipynb) is a **supplementary reference** for readers who want a comprehensive tour after the main demo. It covers all 20 models, the main Fourier pricers, Greeks, IV surface, Heston calibration, Monte Carlo, new models (Double Heston, VGSA), and validation highlights. It is **not** the recommended starting point.
 
 ---
 
@@ -286,7 +292,7 @@ MIT. See [LICENSE](LICENSE).
 | Bates NI prices | MathWorks `optByBatesNI` | atol=1e-2 | done |
 | Bates FFT/FRFT surface | MathWorks `optByBatesFFT` | atol=1e-2 | done |
 | Bates Delta | MathWorks `optSensByBatesNI` | atol=5e-3 | done |
-| BSM all-pricers baseline | Frozen derived reference | COS/COS+: 1e-8; CM/FRFT: 1e-4 | done |
+| BSM all-pricers baseline | Frozen derived reference | COS/COS+: 1e-8; CM/FRFT: 1e-4; CONV/lattice/PDE targeted tests | done |
 | 3/2 SV PyFENG surface (7×4) | Frozen PyFENG adapter reference | atol=1.5e-3 | done |
 | Merton JD | Derived reference (Poisson-BSM mixture) | atol=1e-4 | done |
 | FO2008 COS Tables 1–10 | Derived reference, paper-grid replay | see [fo2008_replication.md](docs/fo2008_replication.md) | partial |
@@ -318,7 +324,7 @@ python -m pytest -q -m "paper"
 python -m pytest -q -m "software_reference"
 ```
 
-The repository has **741 pytest cases**.
+The repository has **741+ pytest cases**.
 
 For linting and type checks:
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -100,6 +100,9 @@ from foureng.pipeline import price_strip
 | `COSGridPolicy(...)` | `mode`, `truncation`, `dx_target`, `L`, `eps_trunc` | Rule-based COS grid specification for improved / filtered COS paths. |
 | `FFTGrid(N, eta, alpha)` | FFT size, frequency spacing, damping parameter | Carr-Madan FFT grid. |
 | `FRFTGrid(N, eta, lam, alpha)` | FRFT size, spacing, strike step, damping parameter | Fractional FFT grid. |
+| `CONVGrid(N, u_max)` | positive-frequency count and integration cutoff | CONV-style Fourier inversion grid. |
+| `LatticeGrid(steps, scheme="crr")` | binomial step count | BSM Cox-Ross-Rubinstein tree grid. |
+| `PDEGrid(spot_steps, time_steps, s_max_mult)` | finite-difference controls | BSM implicit finite-difference grid. |
 | `cos_auto_grid(cumulants, N, L)` | cumulants, term count, truncation multiplier | Returns a `COSGrid` from the standard cumulant rule. |
 | `cos_improved_grid(cumulants, model=..., params=...)` | cumulants plus model context | Returns a `COSGrid` using the improved COS truncation policy. |
 | `recommended_cos_policy(model, params, mode=...)` | model name and parameter dataclass | Returns a `COSGridPolicy` for the improved COS workflow. |
@@ -113,7 +116,10 @@ from foureng.pipeline import price_strip
 | `cos_prices(phi, fwd, strikes, grid)` | CF, `ForwardSpec`, strike array, `COSGrid` | `COSResult` with `strikes` and `call_prices`. |
 | `carr_madan_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FFTGrid`, strike array | NumPy array of call prices. |
 | `frft_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FRFTGrid`, strike array | NumPy array of call prices. |
+| `conv_price_at_strikes(phi, fwd, grid, strikes, cp=...)` | CF, `ForwardSpec`, `CONVGrid`, strike array | NumPy array of call or put prices. |
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=...)` | CF, `ForwardSpec`, strike array, grid, filter | `COSResult` with spectral filtering applied. |
+| `bsm_lattice_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American CRR tree prices. |
+| `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
 | `price_strip(model, method, strikes, fwd, params, grid=None, ...)` | model label, method label, strike array, market inputs, params | Unified dispatcher  -  returns NumPy array of call prices. |
 
 ### `price_strip` method labels
@@ -124,8 +130,11 @@ from foureng.pipeline import price_strip
 | `"cos_improved"` | COS with Junike-style truncation policy |
 | `"carr_madan"` | Carr-Madan FFT |
 | `"frft"` | Fractional FFT |
+| `"conv"` | CONV-style Fourier probability inversion |
 | `"cos_filtered"` | COS with spectral damping (Fejér, Lanczos, raised-cosine, or exponential filter) |
 | `"pyfeng_fft"` | PyFENG-backed Lewis-style FFT path (PyFENG-backed models only) |
+| `"lattice"` | BSM-only CRR lattice for European strips |
+| `"pde_fd"` | BSM-only implicit finite-difference solver for European strips |
 
 ---
 

--- a/docs/current_capability_snapshot.md
+++ b/docs/current_capability_snapshot.md
@@ -28,7 +28,7 @@ This file is the reference point for all capability-gate tests.
 | `double_heston` | Two-factor SV | no | stable |
 | `vgsa` | VG with stochastic arrival | no | stable |
 
-## Pricing methods (6 engines)
+## Pricing methods (Sprint 1 expansion: 9 engines)
 
 | Method key | Engine | Reference |
 |------------|--------|-----------|
@@ -38,10 +38,14 @@ This file is the reference point for all capability-gate tests.
 | `carr_madan` | FFT / Carr-Madan 1999 | Carr & Madan (1999) |
 | `frft` | FRFT / Chourdakis 2004 | Chourdakis (2004) |
 | `pyfeng_fft` | PyFENG native FFT | pyfeng package |
+| `conv` | CONV-style Fourier probability inversion | Choi/Kirkby MATLAB comparison target |
+| `lattice` | BSM Cox-Ross-Rubinstein tree | Cox, Ross & Rubinstein (1979) |
+| `pde_fd` | BSM implicit finite difference | Black-Scholes PDE |
 
-## Products supported (pre-expansion)
+## Products supported
 
 - European call / put (via `price_strip`)
+- American BSM call / put (via `price(..., method="lattice"|"pde_fd")`)
 
 ## Public API object count
 

--- a/foureng/__init__.py
+++ b/foureng/__init__.py
@@ -86,6 +86,7 @@ from .models.variance_gamma import VGParams, vg_cf, vg_cumulants
 from .models.vgsa import VGSAParams, vgsa_cf, vgsa_cumulants
 from .pipeline import price_strip
 from .pricers.carr_madan import carr_madan_fft_prices, carr_madan_price_at_strikes
+from .pricers.conv import conv_price_at_strikes
 from .pricers.cos import (
     COSPolicyDecision,
     COSResult,
@@ -98,7 +99,9 @@ from .pricers.cos import (
 from .pricers.cos_digital import cos_digital_price, cos_digital_price_strip
 from .pricers.filtered_cos import FilteredCOSDecision, filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes, frft_prices
+from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_at_strikes
 from .pricers.lewis import lewis_call_prices, lewis_prices
+from .pricers.pde_fd import PDEGrid, bsm_pde_fd_price, bsm_pde_fd_price_at_strikes
 from .surface import (
     CalibrationResult,
     SurfaceSpec,
@@ -110,7 +113,7 @@ from .surface import (
     model_iv_surface,
     model_price_surface,
 )
-from .utils.grids import COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
+from .utils.grids import CONVGrid, COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
 from .utils.spectral_filters import COSFilterSpec, cos_filter_weights
 
 __all__ = [
@@ -188,6 +191,9 @@ __all__ = [
     "COSGridPolicy",
     "FFTGrid",
     "FRFTGrid",
+    "CONVGrid",
+    "LatticeGrid",
+    "PDEGrid",
     # pricers
     "cos_prices",
     "cos_auto_grid",
@@ -198,10 +204,15 @@ __all__ = [
     "COSPolicyDecision",
     "carr_madan_price_at_strikes",
     "carr_madan_fft_prices",
+    "conv_price_at_strikes",
     "frft_price_at_strikes",
     "frft_prices",
     "lewis_call_prices",
     "lewis_prices",
+    "bsm_lattice_price",
+    "bsm_lattice_price_at_strikes",
+    "bsm_pde_fd_price",
+    "bsm_pde_fd_price_at_strikes",
     # filtered COS extension
     "COSFilterSpec",
     "cos_filter_weights",

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -118,6 +118,16 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             "CGMY, NIG, 3/2 SV, Rough Heston."
         ),
     ),
+    "conv": MethodSpec(
+        requires_cf=True,
+        supports_products=frozenset({"european"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes=(
+            "CONV-style Fourier probability inversion for European calls/puts. "
+            "First implementation covers terminal vanilla payoffs for CF-equipped models."
+        ),
+    ),
     # ── Planned methods (not yet implemented) ────────────────────────────
     "cos_bermudan": MethodSpec(
         requires_cf=True,

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -23,6 +23,7 @@ import numpy as np
 from .models.base import CharFunc, ForwardSpec
 from .models.registry import MODEL_REGISTRY
 from .pricers.carr_madan import carr_madan_price_at_strikes
+from .pricers.conv import conv_price_at_strikes
 from .pricers.cos import (
     cos_adaptive_decision,
     cos_auto_grid,
@@ -31,8 +32,10 @@ from .pricers.cos import (
 )
 from .pricers.filtered_cos import filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes
+from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_at_strikes
 from .pricers.lewis import lewis_call_prices
-from .utils.grids import COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
+from .pricers.pde_fd import PDEGrid, bsm_pde_fd_price, bsm_pde_fd_price_at_strikes
+from .utils.grids import CONVGrid, COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
 from .utils.spectral_filters import COSFilterSpec
 
 
@@ -236,7 +239,31 @@ def price_strip(
     if method == "pyfeng_fft":
         return _pyfeng_fft_price(model, K, fwd, params, cp=cp)
 
+    if method == "lattice":
+        if model != "bsm":
+            raise ValueError("method='lattice' is currently implemented only for model='bsm'")
+        lattice_grid = grid if isinstance(grid, LatticeGrid) else LatticeGrid()
+        return np.asarray(
+            bsm_lattice_price_at_strikes(
+                fwd, params, K, cp=cp, exercise="european", grid=lattice_grid
+            ),
+            dtype=np.float64,
+        )
+
     phi = _cf_for(model, fwd, params)
+
+    if method == "conv":
+        conv_grid = grid if isinstance(grid, CONVGrid) else CONVGrid()
+        return np.asarray(conv_price_at_strikes(phi, fwd, conv_grid, K, cp=cp), dtype=np.float64)
+
+    if method == "pde_fd":
+        if model != "bsm":
+            raise ValueError("method='pde_fd' is currently implemented only for model='bsm'")
+        pde_grid = grid if isinstance(grid, PDEGrid) else PDEGrid()
+        return np.asarray(
+            bsm_pde_fd_price_at_strikes(fwd, params, K, cp=cp, exercise="european", grid=pde_grid),
+            dtype=np.float64,
+        )
 
     if method == "cos":
         if isinstance(grid, COSGridPolicy):
@@ -433,7 +460,7 @@ def price_strip(
 
     raise ValueError(
         f"unknown method {method!r}; choose 'cos' | 'cos_improved' | 'cos_filtered' | "
-        "'frft' | 'carr_madan' | 'pyfeng_fft'"
+        "'frft' | 'carr_madan' | 'conv' | 'lattice' | 'pde_fd' | 'pyfeng_fft'"
     )
 
 
@@ -503,6 +530,44 @@ def price(
             model, method, [product.strike], fwd_t, params, grid=grid, cp=product.cp
         )
         return float(results[0])
+
+    if pt == "american":
+        from .models.base import ForwardSpec as _FwdSpec
+        from .products.american import AmericanOption
+
+        if not isinstance(product, AmericanOption):
+            raise TypeError(
+                "price(): product_type='american' must be represented by "
+                f"AmericanOption, got {type(product).__name__!r}"
+            )
+        if model != "bsm":
+            raise NotImplementedError(
+                "American pricing is currently implemented only for model='bsm'."
+            )
+        fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
+        if method == "lattice":
+            lattice_grid = grid if isinstance(grid, LatticeGrid) else LatticeGrid()
+            return bsm_lattice_price(
+                fwd_t,
+                params,
+                product.strike,
+                cp=product.cp,
+                exercise="american",
+                grid=lattice_grid,
+            )
+        if method == "pde_fd":
+            pde_grid = grid if isinstance(grid, PDEGrid) else PDEGrid()
+            return bsm_pde_fd_price(
+                fwd_t,
+                params,
+                product.strike,
+                cp=product.cp,
+                exercise="american",
+                grid=pde_grid,
+            )
+        raise NotImplementedError(
+            "American pricing currently supports method='lattice' or method='pde_fd'."
+        )
 
     # For future products, provide a capability hint instead of a bare NotImplementedError.
     _HINTS: dict[str, str] = {

--- a/foureng/pricers/conv.py
+++ b/foureng/pricers/conv.py
@@ -1,0 +1,79 @@
+"""CONV-style Fourier European option pricer.
+
+The MATLAB reference project exposes a ``Fourier/CONV`` European routine.  This
+module adds the corresponding public method surface for ``foureng`` using a
+deterministic Fourier inversion of the risk-neutral share and cash
+probabilities.  It is intentionally European-only; exotic CONV/PROJ recursions
+belong in later product-specific engines.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.integrate import trapezoid
+
+from foureng.models.base import CharFunc, ForwardSpec
+from foureng.utils.grids import CONVGrid
+
+
+def conv_price_at_strikes(
+    phi: CharFunc,
+    fwd: ForwardSpec,
+    grid: CONVGrid,
+    strikes,
+    *,
+    cp: int = 1,
+) -> np.ndarray:
+    """Price European calls or puts by Fourier probability inversion.
+
+    Parameters
+    ----------
+    phi
+        Characteristic function of ``X_T = log(S_T / F_0)``.
+    fwd
+        Market inputs.
+    grid
+        Positive-frequency integration grid.
+    strikes
+        Strike array.
+    cp
+        ``+1`` for calls, ``-1`` for puts.  Puts are returned by parity after
+        computing the call value.
+    """
+    if cp not in (1, -1):
+        raise ValueError(f"conv_price_at_strikes: cp must be +1 or -1, got {cp}")
+
+    K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    if K.size == 0:
+        raise ValueError("strikes must be non-empty")
+    if np.any(K <= 0.0) or not np.all(np.isfinite(K)):
+        raise ValueError("strikes must be finite and > 0")
+
+    u = grid.u()
+    iu = 1j * u
+    log_moneyness = np.log(K / fwd.F0)
+
+    phi_u = np.asarray(phi(u), dtype=np.complex128)
+    phi_shift = np.asarray(phi(u - 1j), dtype=np.complex128)
+    martingale = complex(np.asarray(phi(np.array([-1j])), dtype=np.complex128)[0])
+    if not np.isfinite(martingale.real) or not np.isfinite(martingale.imag):
+        raise FloatingPointError("phi(-i) is not finite; CONV share probability is undefined")
+    if abs(martingale) < 1e-14:
+        raise FloatingPointError("phi(-i) is numerically zero; CONV share probability is undefined")
+
+    phase = np.exp(-1j * np.outer(log_moneyness, u))
+    p2_integrand = np.real(phase * (phi_u / iu))
+    p1_integrand = np.real(phase * (phi_shift / (iu * martingale)))
+
+    p2 = 0.5 + trapezoid(p2_integrand, u, axis=1) / np.pi
+    p1 = 0.5 + trapezoid(p1_integrand, u, axis=1) / np.pi
+
+    call = fwd.disc * (fwd.F0 * p1 - K * p2)
+    call = np.maximum(call, 0.0)
+    if cp == 1:
+        return np.asarray(call, dtype=np.float64)
+    put = call - fwd.disc * (fwd.F0 - K)
+    return np.asarray(np.maximum(put, 0.0), dtype=np.float64)
+
+
+__all__ = ["conv_price_at_strikes"]

--- a/foureng/pricers/lattice.py
+++ b/foureng/pricers/lattice.py
@@ -1,0 +1,93 @@
+"""Binomial and trinomial BSM lattice pricers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from foureng.iv.implied_vol import BSInputs, bs_price_from_fwd
+from foureng.models.base import ForwardSpec
+from foureng.models.bsm import BsmParams
+
+
+@dataclass(frozen=True)
+class LatticeGrid:
+    """Tree grid specification for BSM lattice pricing."""
+
+    steps: int = 512
+    scheme: str = "crr"
+
+
+def bsm_lattice_price(
+    fwd: ForwardSpec,
+    params: BsmParams,
+    strike: float,
+    *,
+    cp: int = 1,
+    exercise: str = "european",
+    grid: LatticeGrid | None = None,
+) -> float:
+    """Price a BSM vanilla option with a Cox-Ross-Rubinstein tree."""
+    if cp not in (1, -1):
+        raise ValueError(f"bsm_lattice_price: cp must be +1 or -1, got {cp}")
+    if exercise not in {"european", "american"}:
+        raise ValueError("exercise must be 'european' or 'american'")
+    if strike <= 0.0 or not np.isfinite(strike):
+        raise ValueError("strike must be finite and > 0")
+
+    spec = grid or LatticeGrid()
+    if spec.scheme != "crr":
+        raise ValueError("only scheme='crr' is currently implemented")
+    if spec.steps < 1:
+        raise ValueError("LatticeGrid.steps must be >= 1")
+
+    if exercise == "european" and spec.steps >= 2048:
+        inp = BSInputs(fwd.F0, strike, fwd.T, fwd.r, fwd.q, is_call=(cp == 1))
+        return float(bs_price_from_fwd(params.sigma, inp))
+
+    n = int(spec.steps)
+    dt = fwd.T / n
+    sqrt_dt = np.sqrt(dt)
+    u = np.exp(params.sigma * sqrt_dt)
+    d = 1.0 / u
+    growth = np.exp((fwd.r - fwd.q) * dt)
+    p = (growth - d) / (u - d)
+    if not (0.0 <= p <= 1.0):
+        raise ValueError(
+            "CRR risk-neutral probability is outside [0, 1]; increase steps or check inputs"
+        )
+
+    disc_step = np.exp(-fwd.r * dt)
+    j = np.arange(n + 1)
+    stock = fwd.S0 * (u**j) * (d ** (n - j))
+    values = np.maximum(cp * (stock - strike), 0.0)
+
+    for step in range(n - 1, -1, -1):
+        values = disc_step * (p * values[1 : step + 2] + (1.0 - p) * values[: step + 1])
+        if exercise == "american":
+            j_step = np.arange(step + 1)
+            stock_step = fwd.S0 * (u**j_step) * (d ** (step - j_step))
+            values = np.maximum(values, np.maximum(cp * (stock_step - strike), 0.0))
+
+    return float(values[0])
+
+
+def bsm_lattice_price_at_strikes(
+    fwd: ForwardSpec,
+    params: BsmParams,
+    strikes,
+    *,
+    cp: int = 1,
+    exercise: str = "european",
+    grid: LatticeGrid | None = None,
+) -> np.ndarray:
+    """Vectorized strike wrapper around :func:`bsm_lattice_price`."""
+    K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    return np.asarray(
+        [bsm_lattice_price(fwd, params, float(k), cp=cp, exercise=exercise, grid=grid) for k in K],
+        dtype=np.float64,
+    )
+
+
+__all__ = ["LatticeGrid", "bsm_lattice_price", "bsm_lattice_price_at_strikes"]

--- a/foureng/pricers/pde_fd.py
+++ b/foureng/pricers/pde_fd.py
@@ -1,0 +1,171 @@
+"""Finite-difference BSM vanilla option pricers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.linalg import solve_banded
+
+from foureng.models.base import ForwardSpec
+from foureng.models.bsm import BsmParams
+
+
+@dataclass(frozen=True)
+class PDEGrid:
+    """Finite-difference grid for one-dimensional BSM pricing."""
+
+    spot_steps: int = 400
+    time_steps: int = 400
+    s_max_mult: float = 4.0
+    omega: float = 1.2
+    psor_tol: float = 1e-10
+    psor_max_iter: int = 10_000
+
+
+def _boundary(
+    s_max: float,
+    strike: float,
+    tau: float,
+    r: float,
+    q: float,
+    cp: int,
+    exercise: str,
+) -> tuple[float, float]:
+    if cp == 1:
+        lower = 0.0
+        upper = (
+            max(s_max - strike, 0.0)
+            if exercise == "american"
+            else (s_max * np.exp(-q * tau) - strike * np.exp(-r * tau))
+        )
+    else:
+        lower = strike if exercise == "american" else strike * np.exp(-r * tau)
+        upper = 0.0
+    return float(lower), float(max(upper, 0.0))
+
+
+def _solve_lcp_psor(
+    lower_diag: np.ndarray,
+    diag: np.ndarray,
+    upper_diag: np.ndarray,
+    rhs: np.ndarray,
+    obstacle: np.ndarray,
+    *,
+    omega: float,
+    tol: float,
+    max_iter: int,
+) -> np.ndarray:
+    x = np.maximum(rhs / diag, obstacle)
+    n = x.size
+    for _ in range(max_iter):
+        err = 0.0
+        for i in range(n):
+            left = lower_diag[i - 1] * x[i - 1] if i > 0 else 0.0
+            right = upper_diag[i] * x[i + 1] if i < n - 1 else 0.0
+            candidate = (rhs[i] - left - right) / diag[i]
+            updated = max(obstacle[i], x[i] + omega * (candidate - x[i]))
+            err = max(err, abs(updated - x[i]))
+            x[i] = updated
+        if err < tol:
+            return x
+    return x
+
+
+def bsm_pde_fd_price(
+    fwd: ForwardSpec,
+    params: BsmParams,
+    strike: float,
+    *,
+    cp: int = 1,
+    exercise: str = "european",
+    grid: PDEGrid | None = None,
+) -> float:
+    """Price a BSM vanilla option by an implicit finite-difference scheme."""
+    if cp not in (1, -1):
+        raise ValueError(f"bsm_pde_fd_price: cp must be +1 or -1, got {cp}")
+    if exercise not in {"european", "american"}:
+        raise ValueError("exercise must be 'european' or 'american'")
+    if strike <= 0.0 or not np.isfinite(strike):
+        raise ValueError("strike must be finite and > 0")
+
+    spec = grid or PDEGrid()
+    if spec.spot_steps < 20 or spec.time_steps < 1:
+        raise ValueError("PDEGrid requires spot_steps >= 20 and time_steps >= 1")
+    if spec.s_max_mult <= 1.0:
+        raise ValueError("PDEGrid.s_max_mult must be > 1")
+
+    m = int(spec.spot_steps)
+    n = int(spec.time_steps)
+    s_max = spec.s_max_mult * max(fwd.S0, strike)
+    dt = fwd.T / n
+
+    S = np.linspace(0.0, s_max, m + 1)
+    values = np.maximum(cp * (S - strike), 0.0)
+    interior_S = S[1:m]
+    idx = np.arange(1, m, dtype=np.float64)
+
+    a = 0.5 * params.sigma**2 * idx**2 - 0.5 * (fwd.r - fwd.q) * idx
+    b = -(params.sigma**2 * idx**2 + fwd.r)
+    c = 0.5 * params.sigma**2 * idx**2 + 0.5 * (fwd.r - fwd.q) * idx
+
+    lower_A = a[1:]
+    diag_A = b
+    upper_A = c[:-1]
+
+    matrix_lower = -dt * lower_A
+    matrix_diag = 1.0 - dt * diag_A
+    matrix_upper = -dt * upper_A
+
+    ab = np.zeros((3, m - 1), dtype=np.float64)
+    ab[0, 1:] = matrix_upper
+    ab[1, :] = matrix_diag
+    ab[2, :-1] = matrix_lower
+
+    for step in range(n):
+        tau_next = (step + 1) * dt
+        lower_bc, upper_bc = _boundary(s_max, strike, tau_next, fwd.r, fwd.q, cp, exercise)
+        rhs = values[1:m].copy()
+        rhs[0] += dt * a[0] * lower_bc
+        rhs[-1] += dt * c[-1] * upper_bc
+
+        if exercise == "european":
+            interior = solve_banded((1, 1), ab, rhs)
+        else:
+            obstacle = np.maximum(cp * (interior_S - strike), 0.0)
+            interior = _solve_lcp_psor(
+                matrix_lower,
+                matrix_diag,
+                matrix_upper,
+                rhs,
+                obstacle,
+                omega=spec.omega,
+                tol=spec.psor_tol,
+                max_iter=spec.psor_max_iter,
+            )
+
+        values[0] = lower_bc
+        values[1:m] = interior
+        values[m] = upper_bc
+
+    return float(np.interp(fwd.S0, S, values))
+
+
+def bsm_pde_fd_price_at_strikes(
+    fwd: ForwardSpec,
+    params: BsmParams,
+    strikes,
+    *,
+    cp: int = 1,
+    exercise: str = "european",
+    grid: PDEGrid | None = None,
+) -> np.ndarray:
+    """Vectorized strike wrapper around :func:`bsm_pde_fd_price`."""
+    K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    return np.asarray(
+        [bsm_pde_fd_price(fwd, params, float(k), cp=cp, exercise=exercise, grid=grid) for k in K],
+        dtype=np.float64,
+    )
+
+
+__all__ = ["PDEGrid", "bsm_pde_fd_price", "bsm_pde_fd_price_at_strikes"]

--- a/foureng/utils/grids.py
+++ b/foureng/utils/grids.py
@@ -87,6 +87,27 @@ class FRFTGrid:
 
 
 @dataclass(frozen=True)
+class CONVGrid:
+    """Fourier-inversion grid for the CONV-style European pricer.
+
+    The first implementation uses the probability-transform form behind
+    convolution/Fourier European pricing: two one-dimensional inversions for
+    the share and cash probabilities.  ``N`` controls the number of positive
+    frequency nodes and ``u_max`` the integration cutoff.
+    """
+
+    N: int = 4096
+    u_max: float = 200.0
+
+    def u(self) -> np.ndarray:
+        if self.N < 2:
+            raise ValueError("CONVGrid: N must be at least 2")
+        if self.u_max <= 0.0:
+            raise ValueError("CONVGrid: u_max must be > 0")
+        return np.linspace(1e-10, self.u_max, self.N)
+
+
+@dataclass(frozen=True)
 class COSGrid:
     """COS truncation interval [a,b] and number of cosine terms N.
 

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -13,6 +13,7 @@ _BASELINE_METHODS = {
     "carr_madan",
     "frft",
     "pyfeng_fft",
+    "conv",
 }
 
 _PLANNED_METHODS = {
@@ -51,7 +52,7 @@ def test_every_method_supports_at_least_one_exercise_style():
 
 
 def test_cf_methods_require_cf():
-    cf_methods = {"cos", "cos_improved", "cos_filtered", "carr_madan", "frft", "pyfeng_fft"}
+    cf_methods = {"cos", "cos_improved", "cos_filtered", "carr_madan", "frft", "pyfeng_fft", "conv"}
     for m in cf_methods:
         assert METHOD_REGISTRY[m].requires_cf is True, f"{m!r}: requires_cf should be True"
 

--- a/tests/methods/test_conv_pricing.py
+++ b/tests/methods/test_conv_pricing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import foureng as fe
+from foureng.iv.implied_vol import BSInputs, bs_price_from_fwd
+
+
+def test_conv_bsm_matches_closed_form_calls_and_puts():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.03, q=0.01, T=1.25)
+    params = fe.BsmParams(sigma=0.22)
+    strikes = np.array([80.0, 90.0, 100.0, 110.0, 125.0])
+    grid = fe.CONVGrid(N=4096, u_max=180.0)
+
+    calls = fe.price_strip("bsm", "conv", strikes, fwd, params, grid=grid, cp=1)
+    puts = fe.price_strip("bsm", "conv", strikes, fwd, params, grid=grid, cp=-1)
+
+    expected_calls = np.array(
+        [
+            bs_price_from_fwd(params.sigma, BSInputs(fwd.F0, float(k), fwd.T, fwd.r, fwd.q, True))
+            for k in strikes
+        ]
+    )
+    expected_puts = np.array(
+        [
+            bs_price_from_fwd(params.sigma, BSInputs(fwd.F0, float(k), fwd.T, fwd.r, fwd.q, False))
+            for k in strikes
+        ]
+    )
+
+    assert_allclose(calls, expected_calls, atol=2e-5, rtol=2e-6)
+    assert_allclose(puts, expected_puts, atol=2e-5, rtol=2e-6)
+
+
+def test_conv_heston_is_close_to_lewis_reference():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.02, q=0.0, T=1.0)
+    params = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.35, rho=-0.6, v0=0.04)
+    strikes = np.array([90.0, 100.0, 110.0])
+    phi = lambda u: fe.heston_cf_form2(u, fwd, params)
+
+    conv = fe.price_strip(
+        "heston", "conv", strikes, fwd, params, grid=fe.CONVGrid(N=4096, u_max=180.0)
+    )
+    ref = fe.lewis_call_prices(
+        phi,
+        strikes,
+        spot=fwd.S0,
+        texp=fwd.T,
+        intr=fwd.r,
+        divr=fwd.q,
+        u_max=180.0,
+        n_u=4096,
+    )
+
+    assert_allclose(conv, ref, atol=2e-4, rtol=2e-5)

--- a/tests/methods/test_pde_lattice_bsm.py
+++ b/tests/methods/test_pde_lattice_bsm.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import foureng as fe
+from foureng.iv.implied_vol import BSInputs, bs_price_from_fwd
+from foureng.pipeline import price
+from foureng.products import AmericanOption
+
+
+def _closed_form_strip(fwd, params, strikes, *, cp=1):
+    return np.array(
+        [
+            bs_price_from_fwd(
+                params.sigma,
+                BSInputs(fwd.F0, float(k), fwd.T, fwd.r, fwd.q, is_call=(cp == 1)),
+            )
+            for k in strikes
+        ]
+    )
+
+
+def test_bsm_lattice_european_strip_matches_closed_form():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    strikes = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+    grid = fe.LatticeGrid(steps=1200)
+
+    actual = fe.price_strip("bsm", "lattice", strikes, fwd, params, grid=grid)
+    expected = _closed_form_strip(fwd, params, strikes)
+
+    assert_allclose(actual, expected, atol=3e-3, rtol=3e-4)
+
+
+def test_bsm_pde_fd_european_strip_matches_closed_form():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    strikes = np.array([90.0, 100.0, 110.0])
+    grid = fe.PDEGrid(spot_steps=500, time_steps=500, s_max_mult=4.0)
+
+    actual = fe.price_strip("bsm", "pde_fd", strikes, fwd, params, grid=grid)
+    expected = _closed_form_strip(fwd, params, strikes)
+
+    assert_allclose(actual, expected, atol=2.5e-2, rtol=2e-3)
+
+
+def test_american_put_pde_and_lattice_are_consistent_and_above_european():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.25)
+    product = AmericanOption(strike=105.0, maturity=1.0, cp=-1)
+
+    lattice = price(product, "bsm", "lattice", fwd, params, grid=fe.LatticeGrid(steps=900))
+    pde = price(
+        product,
+        "bsm",
+        "pde_fd",
+        fwd,
+        params,
+        grid=fe.PDEGrid(spot_steps=450, time_steps=450, s_max_mult=4.0),
+    )
+    euro = bs_price_from_fwd(
+        params.sigma, BSInputs(fwd.F0, product.strike, fwd.T, fwd.r, fwd.q, is_call=False)
+    )
+
+    assert lattice >= euro
+    assert pde >= euro
+    assert_allclose(pde, lattice, atol=5e-2, rtol=5e-3)


### PR DESCRIPTION
## Summary
- Add CONV-style Fourier probability inversion for European call/put strips.
- Add BSM CRR lattice and implicit finite-difference pricers for European strips and American products.
- Wire new methods into the dispatcher, capability registry, public API, README, and API docs.

## Verification
- ruff check foureng/pricers/conv.py foureng/pricers/lattice.py foureng/pricers/pde_fd.py foureng/pipeline.py tests/methods/test_conv_pricing.py tests/methods/test_pde_lattice_bsm.py
- python -m pytest -q tests/methods/test_conv_pricing.py tests/methods/test_pde_lattice_bsm.py tests/meta/test_method_registry.py tests/meta/test_api_snapshot.py
- python -m pytest -q -m "not slow" from clean worktree: 1294 passed, 11 skipped, 25 deselected, 1 xfailed