### PR TITLE
Add BSM barrier product pricer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ where $c_1, c_2, c_4$ are the model's cumulants and $L$ is a heuristic multiplie
 
 This project implements the **improved COS truncation** of Junike & Pankrashkin (2022) and Junike (2024), which replaces the heuristic $L$ with a rigorous tail-mass bound. On the FO2008 test suite, this truncation improvement beats the paper-grid COS in 7 of 8 cases and beats the paper's own best-N result in 6 of 8 (see [`benchmarks/cos_method_improved/`](benchmarks/cos_method_improved/outputs/cos_method_improved_paper_compare.csv)). On top of that, we add an **original adaptive filtered-COS extension**: spectral weights $\sigma_k \in [0, 1]$ (Fejér, Lanczos, raised-cosine, or exponential) applied to the high-frequency COS coefficients to suppress residual oscillation from sharp density features. A policy-search selector automatically compares grid and filter combinations, returning the fastest configuration that meets the user's tolerance, with the plain Junike path always included as a fallback.
 
-The package covers **20 models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, all priced through one `price_strip` dispatcher with **7 characteristic-function engines** plus BSM finite-difference and lattice baselines.
+The package covers **20 models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, all priced through one `price_strip` dispatcher with **7 characteristic-function engines** plus BSM finite-difference, lattice, and analytic barrier baselines.
 
 Full methodology: [appendix.md](appendix.md) · Extension details: [docs/filtered_cos_extension.md](docs/filtered_cos_extension.md) · Package architecture: [docs/architecture_overview.md](docs/architecture_overview.md).
 
@@ -208,6 +208,8 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 
 Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` and `"lattice"`.
 
+Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, BSM American options via `"lattice"` / `"pde_fd"`, and continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`.
+
 ### Core pricing functions
 
 | Function | Parameters | Returns |
@@ -219,6 +221,7 @@ Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"fr
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=None)` | CF, `ForwardSpec`, strike array, `COSGrid`, optional `COSFilterSpec` | `COSResult` |
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `LatticeGrid`, strike array | `np.ndarray` |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `PDEGrid`, strike array | `np.ndarray` |
+| `bsm_barrier_price(S, K, H, r, q, T, sigma, barrier_type, cp=1)` | BSM single-barrier inputs | `float` |
 
 ### Grid constructors
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -5,7 +5,7 @@ Complete public API for `foureng`. All objects are importable as `import foureng
 ```python
 import foureng as fe
 # or for the unified dispatcher only:
-from foureng.pipeline import price_strip
+from foureng.pipeline import price, price_strip
 ```
 
 ---
@@ -120,7 +120,9 @@ from foureng.pipeline import price_strip
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=...)` | CF, `ForwardSpec`, strike array, grid, filter | `COSResult` with spectral filtering applied. |
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American CRR tree prices. |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
+| `bsm_barrier_price(S, K, H, r, q, T, sigma, barrier_type, cp=...)` | BSM single-barrier inputs | Closed-form continuous zero-rebate barrier price. |
 | `price_strip(model, method, strikes, fwd, params, grid=None, ...)` | model label, method label, strike array, market inputs, params | Unified dispatcher  -  returns NumPy array of call prices. |
+| `price(product, model, method, fwd, params, grid=None)` | product dataclass, model label, method label, market inputs, params | Product-aware dispatcher for scalar contracts. |
 
 ### `price_strip` method labels
 
@@ -135,6 +137,15 @@ from foureng.pipeline import price_strip
 | `"pyfeng_fft"` | PyFENG-backed Lewis-style FFT path (PyFENG-backed models only) |
 | `"lattice"` | BSM-only CRR lattice for European strips |
 | `"pde_fd"` | BSM-only implicit finite-difference solver for European strips |
+| `"barrier_bsm"` | BSM-only analytic single-barrier pricing through `price()` |
+
+### Product-level dispatcher
+
+| Product | Supported method(s) | Scope |
+|---------|---------------------|-------|
+| `EuropeanOption` | all compatible `price_strip` methods | Vanilla call/put. |
+| `AmericanOption` | `"lattice"`, `"pde_fd"` | BSM call/put. |
+| `BarrierOption` | `"barrier_bsm"` | Continuously monitored, zero-rebate, single-barrier BSM knock-in/knock-out call/put. |
 
 ---
 

--- a/docs/current_capability_snapshot.md
+++ b/docs/current_capability_snapshot.md
@@ -41,11 +41,13 @@ This file is the reference point for all capability-gate tests.
 | `conv` | CONV-style Fourier probability inversion | Choi/Kirkby MATLAB comparison target |
 | `lattice` | BSM Cox-Ross-Rubinstein tree | Cox, Ross & Rubinstein (1979) |
 | `pde_fd` | BSM implicit finite difference | Black-Scholes PDE |
+| `barrier_bsm` | BSM closed-form single-barrier option | Reiner-Rubinstein / Haug |
 
 ## Products supported
 
 - European call / put (via `price_strip`)
 - American BSM call / put (via `price(..., method="lattice"|"pde_fd")`)
+- Continuous zero-rebate BSM single-barrier call / put (via `price(..., method="barrier_bsm")`)
 
 ## Public API object count
 

--- a/foureng/__init__.py
+++ b/foureng/__init__.py
@@ -84,7 +84,7 @@ from .models.rough_heston import RoughHestonParams, rough_heston_cf, rough_hesto
 from .models.sv32 import Sv32Params, sv32_cf, sv32_cumulants
 from .models.variance_gamma import VGParams, vg_cf, vg_cumulants
 from .models.vgsa import VGSAParams, vgsa_cf, vgsa_cumulants
-from .pipeline import price_strip
+from .pipeline import price, price_strip
 from .pricers.carr_madan import carr_madan_fft_prices, carr_madan_price_at_strikes
 from .pricers.conv import conv_price_at_strikes
 from .pricers.cos import (
@@ -185,6 +185,7 @@ __all__ = [
     "vgsa_cf",
     "vgsa_cumulants",
     # pipeline
+    "price",
     "price_strip",
     # grids
     "COSGrid",

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -128,6 +128,16 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             "First implementation covers terminal vanilla payoffs for CF-equipped models."
         ),
     ),
+    "barrier_bsm": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"barrier"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes=(
+            "Closed-form BSM single-barrier pricer for continuously monitored "
+            "zero-rebate knock-in/knock-out calls and puts."
+        ),
+    ),
     # ── Planned methods (not yet implemented) ────────────────────────────
     "cos_bermudan": MethodSpec(
         requires_cf=True,

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import numpy as np
 
+from .analytics.bsm_barrier import bsm_barrier_price
 from .models.base import CharFunc, ForwardSpec
 from .models.registry import MODEL_REGISTRY
 from .pricers.carr_madan import carr_madan_price_at_strikes
@@ -569,10 +570,45 @@ def price(
             "American pricing currently supports method='lattice' or method='pde_fd'."
         )
 
+    if pt == "barrier":
+        from .products.barrier import BarrierOption
+
+        if not isinstance(product, BarrierOption):
+            raise TypeError(
+                "price(): product_type='barrier' must be represented by "
+                f"BarrierOption, got {type(product).__name__!r}"
+            )
+        if method != "barrier_bsm":
+            raise NotImplementedError(
+                "Barrier pricing currently supports method='barrier_bsm' for "
+                "closed-form BSM single-barrier contracts."
+            )
+        if model != "bsm":
+            raise NotImplementedError(
+                "method='barrier_bsm' is currently implemented only for model='bsm'."
+            )
+        if product.monitoring != "continuous":
+            raise NotImplementedError(
+                "method='barrier_bsm' currently supports only continuous monitoring."
+            )
+        if product.rebate != 0.0:
+            raise NotImplementedError("method='barrier_bsm' currently supports only zero rebates.")
+        return bsm_barrier_price(
+            fwd.S0,
+            product.strike,
+            product.barrier,
+            fwd.r,
+            fwd.q,
+            product.maturity,
+            params.sigma,
+            product.barrier_type,
+            cp=product.cp,
+        )
+
     # For future products, provide a capability hint instead of a bare NotImplementedError.
     _HINTS: dict[str, str] = {
         "digital": "Use a COS digital pricer (Phase 4.1) or analytic BSM.",
-        "barrier": "Use barrier_analytic_bsm / barrier_mc / barrier_cos (Phase 4.2).",
+        "barrier": "Use barrier_bsm for continuous zero-rebate BSM barriers.",
         "asian": "Use asian_geometric_bsm / asian_mc / asian_proj (Phase 4.3).",
         "bermudan": "Use cos_bermudan for Lévy models (Phase 3.3).",
         "american": "Use american_lattice / american_pde (Phase 4.4).",

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -14,6 +14,7 @@ _BASELINE_METHODS = {
     "frft",
     "pyfeng_fft",
     "conv",
+    "barrier_bsm",
 }
 
 _PLANNED_METHODS = {

--- a/tests/products/test_barrier_price_dispatch.py
+++ b/tests/products/test_barrier_price_dispatch.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+from pytest import approx
+
+import foureng as fe
+from foureng.analytics.bsm_barrier import bsm_barrier_price, bsm_call
+from foureng.pipeline import price
+from foureng.products import BarrierOption
+
+
+def test_price_dispatches_continuous_zero_rebate_bsm_barrier():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.02, T=99.0)
+    params = fe.BsmParams(sigma=0.25)
+    product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=1.0,
+        cp=1,
+        barrier_type="down_out",
+    )
+
+    actual = price(product, "bsm", "barrier_bsm", fwd, params)
+    expected = bsm_barrier_price(
+        100.0,
+        90.0,
+        80.0,
+        0.05,
+        0.02,
+        1.0,
+        0.25,
+        "down_out",
+        cp=1,
+    )
+
+    assert actual == approx(expected, rel=1e-12, abs=1e-12)
+
+
+@pytest.mark.parametrize("cp", [1, -1])
+@pytest.mark.parametrize("base,barrier,strike", [("down", 80.0, 90.0), ("up", 120.0, 110.0)])
+def test_price_dispatch_preserves_in_out_parity(cp, base, barrier, strike):
+    fwd = fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=1.0)
+    params = fe.BsmParams(sigma=0.22)
+    out_product = BarrierOption(
+        strike=strike,
+        barrier=barrier,
+        maturity=1.0,
+        cp=cp,
+        barrier_type=f"{base}_out",
+    )
+    in_product = BarrierOption(
+        strike=strike,
+        barrier=barrier,
+        maturity=1.0,
+        cp=cp,
+        barrier_type=f"{base}_in",
+    )
+
+    out_price = price(out_product, "bsm", "barrier_bsm", fwd, params)
+    in_price = price(in_product, "bsm", "barrier_bsm", fwd, params)
+    vanilla = fe.bs_price_from_fwd(
+        params.sigma,
+        fe.BSInputs(fwd.F0, strike, fwd.T, fwd.r, fwd.q, is_call=(cp == 1)),
+    )
+
+    assert out_price >= 0.0
+    assert in_price >= 0.0
+    assert out_price + in_price == approx(vanilla, rel=1e-10, abs=1e-10)
+
+
+def test_barrier_bsm_uses_product_maturity_not_forward_spec_maturity():
+    fwd_wrong_t = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=3.0)
+    params = fe.BsmParams(sigma=0.2)
+    product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=0.75,
+        cp=1,
+        barrier_type="down_out",
+    )
+
+    actual = price(product, "bsm", "barrier_bsm", fwd_wrong_t, params)
+    wrong = bsm_barrier_price(100.0, 90.0, 80.0, 0.05, 0.0, 3.0, 0.2, "down_out", cp=1)
+    correct = bsm_barrier_price(100.0, 90.0, 80.0, 0.05, 0.0, 0.75, 0.2, "down_out", cp=1)
+
+    assert actual == approx(correct, rel=1e-12, abs=1e-12)
+    assert abs(actual - wrong) > 1e-3
+
+
+def test_barrier_bsm_rejects_non_bsm_model():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.3, rho=-0.5, v0=0.04)
+    product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=1.0,
+        cp=1,
+        barrier_type="down_out",
+    )
+
+    with pytest.raises(NotImplementedError, match="model='bsm'"):
+        price(product, "heston", "barrier_bsm", fwd, params)
+
+
+def test_barrier_bsm_rejects_rebates_and_discrete_monitoring():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    rebate_product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=1.0,
+        cp=1,
+        barrier_type="down_out",
+        rebate=1.0,
+    )
+    discrete_product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=1.0,
+        cp=1,
+        barrier_type="down_out",
+        monitoring="discrete",
+    )
+
+    with pytest.raises(NotImplementedError, match="zero rebates"):
+        price(rebate_product, "bsm", "barrier_bsm", fwd, params)
+    with pytest.raises(NotImplementedError, match="continuous monitoring"):
+        price(discrete_product, "bsm", "barrier_bsm", fwd, params)
+
+
+def test_barrier_bsm_knockout_is_bounded_by_vanilla():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.02, T=1.0)
+    params = fe.BsmParams(sigma=0.25)
+    product = BarrierOption(
+        strike=90.0,
+        barrier=80.0,
+        maturity=1.0,
+        cp=1,
+        barrier_type="down_out",
+    )
+
+    barrier_price = price(product, "bsm", "barrier_bsm", fwd, params)
+    vanilla = bsm_call(fwd.S0, product.strike, fwd.r, fwd.q, product.maturity, params.sigma)
+
+    assert 0.0 <= barrier_price <= vanilla


### PR DESCRIPTION
## Summary
- Add `barrier_bsm` method capability for continuous zero-rebate BSM single-barrier options.
- Route `BarrierOption` through the product-level `price()` dispatcher with clear unsupported-case errors.
- Export top-level `fe.price` and update README/API/capability docs.
- Add product-level barrier pricing tests for direct dispatch, in-out parity, maturity override, bounds, and unsupported variants.

## Verification
- `ruff format --check foureng/ tests/`
- `ruff check foureng/ tests/`
- `python -m pytest -q tests/products/test_barrier_price_dispatch.py tests/products/test_price_strip_backwards_compatibility.py tests/meta/test_method_registry.py tests/meta/test_unsupported_combinations_fail_clearly.py tests/meta/test_api_snapshot.py`
- `python -m pytest -q -m "not slow"`: 1303 passed, 11 skipped, 25 deselected, 1 xfailed
