### PR TITLE
Add first slices for sprints 1-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ where $c_1, c_2, c_4$ are the model's cumulants and $L$ is a heuristic multiplie
 
 This project implements the **improved COS truncation** of Junike & Pankrashkin (2022) and Junike (2024), which replaces the heuristic $L$ with a rigorous tail-mass bound. On the FO2008 test suite, this truncation improvement beats the paper-grid COS in 7 of 8 cases and beats the paper's own best-N result in 6 of 8 (see [`benchmarks/cos_method_improved/`](benchmarks/cos_method_improved/outputs/cos_method_improved_paper_compare.csv)). On top of that, we add an **original adaptive filtered-COS extension**: spectral weights $\sigma_k \in [0, 1]$ (Fejér, Lanczos, raised-cosine, or exponential) applied to the high-frequency COS coefficients to suppress residual oscillation from sharp density features. A policy-search selector automatically compares grid and filter combinations, returning the fastest configuration that meets the user's tolerance, with the plain Junike path always included as a fallback.
 
-The package covers **20 models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, all priced through one `price_strip` dispatcher with **7 characteristic-function engines** plus BSM finite-difference, lattice, and analytic barrier baselines.
+The package covers **20 characteristic-function models** across stochastic-volatility, jump-diffusion, pure-Lévy, rough-volatility, and hybrid SVJ families, plus a SABR approximation surface. They are priced through one `price_strip` dispatcher with COS/FFT/FRFT/CONV, first-slice Mellin and PROJ façades, BSM finite-difference/lattice baselines, and product-level exotic routes.
 
 Full methodology: [appendix.md](appendix.md) · Extension details: [docs/filtered_cos_extension.md](docs/filtered_cos_extension.md) · Package architecture: [docs/architecture_overview.md](docs/architecture_overview.md).
 
@@ -197,6 +197,7 @@ Everything is importable from `import foureng as fe`.
 | `FMLSParams` | `alpha, sigma` | Finite Moment Log Stable |
 | `DoubleHestonParams` | `kappa1..v01, kappa2..v02` | Two-factor Heston |
 | `VGSAParams` | `C, G, M, kappa, eta, lam` | VG with stochastic activity |
+| `SabrParams` | `alpha, beta, rho, nu` | SABR implied-vol approximation |
 
 Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 
@@ -206,9 +207,9 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 |----------|------------|---------|
 | `price_strip(model, method, strikes, fwd, params, grid=None)` | model label, method label, strike array, `ForwardSpec`, model params, optional grid | `np.ndarray` of call prices |
 
-Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` and `"lattice"`.
+Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` and SABR-only `"sabr_hagan"`.
 
-Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, BSM American options via `"lattice"` / `"pde_fd"`, and continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`.
+Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, and BSM double barriers via `"double_barrier_mc"`.
 
 ### Core pricing functions
 
@@ -222,6 +223,8 @@ Product-level pricing uses `price(product, model, method, fwd, params)`. It curr
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `LatticeGrid`, strike array | `np.ndarray` |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, grid=None)` | BSM inputs, `PDEGrid`, strike array | `np.ndarray` |
 | `bsm_barrier_price(S, K, H, r, q, T, sigma, barrier_type, cp=1)` | BSM single-barrier inputs | `float` |
+| `bsm_discrete_geometric_asian(S, K, r, q, monitoring_times, sigma, cp=1)` | BSM geometric-Asian inputs | `float` |
+| `sabr_hagan_price_at_strikes(fwd, params, strikes)` | `ForwardSpec`, `SabrParams`, strike array | `np.ndarray` |
 
 ### Grid constructors
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -35,6 +35,7 @@ from foureng.pipeline import price, price_strip
 | `FMLSParams(alpha, sigma)` | Stability index and scale | `alpha` in `(1, 2]`, recovers BSM at `alpha=2`. |
 | `DoubleHestonParams(kappa1, theta1, nu1, rho1, v01, kappa2, theta2, nu2, rho2, v02)` | Two independent Heston variance-factor sets | CF factorises as product of two single-Heston CFs. |
 | `VGSAParams(C, G, M, kappa, eta, lam)` | VG tempering rates plus CIR activity-clock parameters | `lam=0` reduces to standard VG. |
+| `SabrParams(alpha, beta, rho, nu)` | SABR approximation parameters | Used by Hagan lognormal implied-vol pricing. |
 
 ---
 
@@ -121,6 +122,10 @@ from foureng.pipeline import price, price_strip
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American CRR tree prices. |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
 | `bsm_barrier_price(S, K, H, r, q, T, sigma, barrier_type, cp=...)` | BSM single-barrier inputs | Closed-form continuous zero-rebate barrier price. |
+| `bsm_discrete_geometric_asian(S, K, r, q, monitoring_times, sigma, cp=...)` | BSM geometric-average inputs | Closed-form discretely monitored geometric Asian price. |
+| `proj_european_price_at_strikes(phi, fwd, cumulants, strikes, cp=...)` | CF, market inputs, cumulants, strikes | First-slice European PROJ façade using COS projection coefficients. |
+| `mellin_price_at_strikes(phi, fwd, strikes, cp=...)` | CF, market inputs, strikes | First-slice European Mellin façade for selected Lévy models. |
+| `sabr_hagan_price_at_strikes(fwd, params, strikes, cp=...)` | `ForwardSpec`, `SabrParams`, strikes | Hagan SABR implied-vol prices. |
 | `price_strip(model, method, strikes, fwd, params, grid=None, ...)` | model label, method label, strike array, market inputs, params | Unified dispatcher  -  returns NumPy array of call prices. |
 | `price(product, model, method, fwd, params, grid=None)` | product dataclass, model label, method label, market inputs, params | Product-aware dispatcher for scalar contracts. |
 
@@ -133,11 +138,14 @@ from foureng.pipeline import price, price_strip
 | `"carr_madan"` | Carr-Madan FFT |
 | `"frft"` | Fractional FFT |
 | `"conv"` | CONV-style Fourier probability inversion |
+| `"mellin"` | First-slice Mellin European façade for VG, NIG, FMLS, bilateral gamma |
+| `"proj"` | First-slice European PROJ façade using COS projection coefficients |
 | `"cos_filtered"` | COS with spectral damping (Fejér, Lanczos, raised-cosine, or exponential filter) |
 | `"pyfeng_fft"` | PyFENG-backed Lewis-style FFT path (PyFENG-backed models only) |
 | `"lattice"` | BSM-only CRR lattice for European strips |
 | `"pde_fd"` | BSM-only implicit finite-difference solver for European strips |
 | `"barrier_bsm"` | BSM-only analytic single-barrier pricing through `price()` |
+| `"sabr_hagan"` | SABR-only Hagan implied-vol approximation for European strips |
 
 ### Product-level dispatcher
 
@@ -146,6 +154,8 @@ from foureng.pipeline import price, price_strip
 | `EuropeanOption` | all compatible `price_strip` methods | Vanilla call/put. |
 | `AmericanOption` | `"lattice"`, `"pde_fd"` | BSM call/put. |
 | `BarrierOption` | `"barrier_bsm"` | Continuously monitored, zero-rebate, single-barrier BSM knock-in/knock-out call/put. |
+| `AsianOption` | `"asian_bsm"`, `"asian_mc"` | BSM fixed-strike geometric closed form or BSM arithmetic/geometric Monte Carlo. |
+| `DoubleBarrierOption` | `"double_barrier_mc"` | BSM zero-rebate double knock-in/knock-out Monte Carlo. |
 
 ---
 

--- a/docs/current_capability_snapshot.md
+++ b/docs/current_capability_snapshot.md
@@ -42,12 +42,21 @@ This file is the reference point for all capability-gate tests.
 | `lattice` | BSM Cox-Ross-Rubinstein tree | Cox, Ross & Rubinstein (1979) |
 | `pde_fd` | BSM implicit finite difference | Black-Scholes PDE |
 | `barrier_bsm` | BSM closed-form single-barrier option | Reiner-Rubinstein / Haug |
+| `asian_bsm` | BSM discrete geometric Asian closed form | Kemna-Vorst style lognormal average |
+| `asian_mc` | BSM Asian Monte Carlo | GBM path simulation |
+| `double_barrier_mc` | BSM double-barrier Monte Carlo | GBM path simulation |
+| `proj` | First-slice European PROJ façade | COS-backed projection baseline |
+| `mellin` | First-slice European Mellin façade | Mellin-transform expansion target |
+| `sabr_hagan` | SABR Hagan approximation | Hagan et al. |
 
 ## Products supported
 
 - European call / put (via `price_strip`)
 - American BSM call / put (via `price(..., method="lattice"|"pde_fd")`)
 - Continuous zero-rebate BSM single-barrier call / put (via `price(..., method="barrier_bsm")`)
+- BSM Asian options (geometric closed form via `asian_bsm`; arithmetic/geometric MC via `asian_mc`)
+- BSM zero-rebate double-barrier options (via `double_barrier_mc`)
+- SABR European call / put strips (via `price_strip("sabr", "sabr_hagan", ...)`)
 
 ## Public API object count
 

--- a/foureng/__init__.py
+++ b/foureng/__init__.py
@@ -29,7 +29,11 @@ try:
 except _PNF:  # editable install without metadata yet
     __version__ = "0.4.1"
 
-from .analytics.bsm_asian import bsm_geometric_asian, bsm_geometric_asian_parity
+from .analytics.bsm_asian import (
+    bsm_discrete_geometric_asian,
+    bsm_geometric_asian,
+    bsm_geometric_asian_parity,
+)
 from .analytics.bsm_barrier import bsm_barrier_price
 from .analytics.bsm_exotics import (
     bsm_forward_start,
@@ -81,6 +85,7 @@ from .models.merton_jd import MertonJDParams, merton_jd_cf, merton_jd_cumulants
 from .models.nig import NigParams, nig_cf, nig_cumulants
 from .models.ousv import OusvParams, ousv_cf, ousv_cumulants
 from .models.rough_heston import RoughHestonParams, rough_heston_cf, rough_heston_cumulants
+from .models.sabr import SabrParams, sabr_hagan_implied_vol
 from .models.sv32 import Sv32Params, sv32_cf, sv32_cumulants
 from .models.variance_gamma import VGParams, vg_cf, vg_cumulants
 from .models.vgsa import VGSAParams, vgsa_cf, vgsa_cumulants
@@ -101,7 +106,10 @@ from .pricers.filtered_cos import FilteredCOSDecision, filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes, frft_prices
 from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_at_strikes
 from .pricers.lewis import lewis_call_prices, lewis_prices
+from .pricers.mellin import mellin_price_at_strikes
 from .pricers.pde_fd import PDEGrid, bsm_pde_fd_price, bsm_pde_fd_price_at_strikes
+from .pricers.proj import proj_european_price_at_strikes
+from .pricers.sabr import sabr_hagan_price_at_strikes
 from .surface import (
     CalibrationResult,
     SurfaceSpec,
@@ -184,6 +192,8 @@ __all__ = [
     "VGSAParams",
     "vgsa_cf",
     "vgsa_cumulants",
+    "SabrParams",
+    "sabr_hagan_implied_vol",
     # pipeline
     "price",
     "price_strip",
@@ -210,6 +220,9 @@ __all__ = [
     "frft_prices",
     "lewis_call_prices",
     "lewis_prices",
+    "mellin_price_at_strikes",
+    "proj_european_price_at_strikes",
+    "sabr_hagan_price_at_strikes",
     "bsm_lattice_price",
     "bsm_lattice_price_at_strikes",
     "bsm_pde_fd_price",
@@ -250,6 +263,7 @@ __all__ = [
     "heston_call_bs_control",
     "CVResult",
     # analytics
+    "bsm_discrete_geometric_asian",
     "bsm_geometric_asian",
     "bsm_geometric_asian_parity",
     "bsm_barrier_price",

--- a/foureng/analytics/bsm_asian.py
+++ b/foureng/analytics/bsm_asian.py
@@ -89,6 +89,50 @@ def bsm_geometric_asian(
         return disc * (K * norm.cdf(-d2) - fwd_adj * norm.cdf(-d1))
 
 
+def bsm_discrete_geometric_asian(
+    S: float,
+    K: float,
+    r: float,
+    q: float,
+    monitoring_times,
+    sigma: float,
+    cp: int = 1,
+) -> float:
+    """BSM closed-form for a discretely monitored geometric-average Asian option.
+
+    If ``G = exp(mean_i log S_{t_i})`` then ``log(G)`` is normally distributed.
+    The formula prices the option as a Black-style option on this lognormal
+    geometric average using its exact first two log moments.
+    """
+    t = np.asarray(monitoring_times, dtype=np.float64)
+    if t.ndim != 1 or t.size == 0:
+        raise ValueError("monitoring_times must be a non-empty 1-D array")
+    if np.any(t <= 0.0) or not np.all(np.diff(t) > 0.0):
+        raise ValueError("monitoring_times must be strictly increasing and positive")
+    if cp not in (1, -1):
+        raise ValueError(f"cp must be +1 or -1, got {cp}")
+
+    n = float(t.size)
+    t_bar = float(np.mean(t))
+    cov_sum = float(np.minimum.outer(t, t).sum())
+    variance = sigma * sigma * cov_sum / (n * n)
+    maturity = float(t[-1])
+    log_mean = np.log(S) + (r - q - 0.5 * sigma * sigma) * t_bar
+    forward_geo = np.exp(log_mean + 0.5 * variance)
+    disc = np.exp(-r * maturity)
+
+    if variance <= 0.0:
+        payoff = max(cp * (forward_geo - K), 0.0)
+        return float(disc * payoff)
+
+    vol = np.sqrt(variance)
+    d1 = (np.log(forward_geo / K) + 0.5 * variance) / vol
+    d2 = d1 - vol
+    if cp == 1:
+        return float(disc * (forward_geo * norm.cdf(d1) - K * norm.cdf(d2)))
+    return float(disc * (K * norm.cdf(-d2) - forward_geo * norm.cdf(-d1)))
+
+
 def bsm_geometric_asian_parity(
     S: float,
     K: float,

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -128,6 +128,23 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             "First implementation covers terminal vanilla payoffs for CF-equipped models."
         ),
     ),
+    "mellin": MethodSpec(
+        requires_cf=True,
+        supports_products=frozenset({"european"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes=(
+            "European Mellin-method façade for VG, NIG, FMLS, and bilateral gamma. "
+            "First slice uses validated transform inversion pending model-specific contours."
+        ),
+    ),
+    "sabr_hagan": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"european"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes="Hagan lognormal SABR implied-vol approximation plus Black pricing.",
+    ),
     "barrier_bsm": MethodSpec(
         requires_cf=False,
         supports_products=frozenset({"barrier"}),
@@ -136,6 +153,40 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
         notes=(
             "Closed-form BSM single-barrier pricer for continuously monitored "
             "zero-rebate knock-in/knock-out calls and puts."
+        ),
+    ),
+    "asian_bsm": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"asian"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes="Closed-form BSM discretely monitored fixed-strike geometric Asian pricer.",
+    ),
+    "asian_mc": MethodSpec(
+        requires_cf=False,
+        requires_simulation=True,
+        supports_products=frozenset({"asian"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes="BSM Monte Carlo arithmetic/geometric Asian pricer.",
+    ),
+    "double_barrier_mc": MethodSpec(
+        requires_cf=False,
+        requires_simulation=True,
+        supports_products=frozenset({"double_barrier"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes="BSM Monte Carlo double-barrier knock-in/knock-out pricer with zero rebate.",
+    ),
+    "proj": MethodSpec(
+        requires_cf=True,
+        supports_products=frozenset({"european"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes=(
+            "PROJ / Frame Projection (Kirkby). First slice exposes European vanilla "
+            "dispatch as a COS-backed projection baseline; exotic B-spline recursions "
+            "are planned."
         ),
     ),
     # ── Planned methods (not yet implemented) ────────────────────────────
@@ -157,6 +208,7 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             {
                 "european",
                 "barrier",
+                "double_barrier",
                 "asian",
                 "lookback",
                 "variance_swap",
@@ -197,17 +249,6 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             "Binomial / trinomial tree (CRR, Jarrow-Rudd). "
             "American exercise via backward induction. "
             "BSM and simple local-vol only."
-        ),
-    ),
-    "proj": MethodSpec(
-        requires_cf=True,
-        supports_products=frozenset({"european", "barrier", "asian", "bermudan", "american"}),
-        supports_exercise=frozenset({"european", "bermudan", "american"}),
-        supports_path_dependent=False,
-        notes=(
-            "PROJ / Frame Projection (Kirkby). Fourier frame projection with "
-            "B-spline basis. Supports Lévy models; path-dependent payoffs "
-            "via projection onto function space."
         ),
     ),
     "ctmc": MethodSpec(

--- a/foureng/mc/engine.py
+++ b/foureng/mc/engine.py
@@ -25,6 +25,7 @@ from .payoffs import (
     asian_arithmetic_payoff,
     asian_geometric_payoff,
     barrier_payoff,
+    double_barrier_payoff,
     european_payoff,
 )
 
@@ -141,6 +142,21 @@ def mc_price(
         paths = gbm_paths(S0, r, q, T, sigma, mc.n_paths, n_steps, rng, antithetic=mc.antithetic)
         dt = T / n_steps
         raw = barrier_payoff(paths, K, H, bt, cp, use_bb_correction=True, sigma=sigma, dt=dt)
+        disc = np.exp(-r * T)
+        return _result(raw * disc, mc.n_paths)
+
+    # ── Double Barrier ────────────────────────────────────────────────────
+    if pt == "double_barrier":
+        T, K, cp = product.maturity, product.strike, product.cp
+        paths = gbm_paths(S0, r, q, T, sigma, mc.n_paths, mc.n_steps, rng, antithetic=mc.antithetic)
+        raw = double_barrier_payoff(
+            paths,
+            K,
+            product.lower_barrier,
+            product.upper_barrier,
+            cp,
+            knockout=product.knockout,
+        )
         disc = np.exp(-r * T)
         return _result(raw * disc, mc.n_paths)
 

--- a/foureng/mc/payoffs.py
+++ b/foureng/mc/payoffs.py
@@ -129,6 +129,24 @@ def barrier_payoff(
     return np.maximum(cp * (S_T - K), 0.0) * active.astype(float)
 
 
+def double_barrier_payoff(
+    paths: np.ndarray,
+    K: float,
+    lower: float,
+    upper: float,
+    cp: int = 1,
+    *,
+    knockout: bool = True,
+) -> np.ndarray:
+    """Double-barrier payoff monitored on the stored path grid."""
+    if lower <= 0.0 or upper <= lower:
+        raise ValueError("double_barrier_payoff requires 0 < lower < upper")
+    survived = (paths.min(axis=1) > lower) & (paths.max(axis=1) < upper)
+    active = survived if knockout else ~survived
+    terminal = paths[:, -1]
+    return np.maximum(cp * (terminal - K), 0.0) * active.astype(float)
+
+
 # ── Brownian bridge correction ─────────────────────────────────────────────
 
 

--- a/foureng/models/__init__.py
+++ b/foureng/models/__init__.py
@@ -25,6 +25,7 @@ In-house native CFs:
     fmls           FMLSParams             -  Finite Moment Log Stable (Carr-Wu 2003)
     double_heston  DoubleHestonParams     -  Two-factor Heston SV (Christoffersen 2009)
     vgsa           VGSAParams             -  VG with Stochastic Arrival (CGMY 2003)
+    sabr           SabrParams             -  SABR Hagan implied-vol approximation
 """
 
 from .base import CharFunc, ForwardSpec, ModelSpec
@@ -45,6 +46,7 @@ from .merton_jd import MertonJDParams, merton_jd_cf, merton_jd_cumulants
 from .nig import NigParams, nig_cf, nig_cumulants
 from .ousv import OusvParams, ousv_cf, ousv_cumulants
 from .rough_heston import RoughHestonParams, rough_heston_cf, rough_heston_cumulants
+from .sabr import SabrParams, sabr_hagan_implied_vol
 from .sv32 import Sv32Params, sv32_cf, sv32_cumulants
 from .variance_gamma import VGParams, vg_cf, vg_cumulants
 from .vgsa import VGSAParams, vgsa_cf, vgsa_cumulants
@@ -137,4 +139,7 @@ __all__ = [
     "VGSAParams",
     "vgsa_cf",
     "vgsa_cumulants",
+    # SABR approximation
+    "SabrParams",
+    "sabr_hagan_implied_vol",
 ]

--- a/foureng/models/sabr.py
+++ b/foureng/models/sabr.py
@@ -1,0 +1,90 @@
+"""SABR approximation parameters and Hagan implied volatility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .base import ModelSpec
+
+
+@dataclass(frozen=True)
+class SabrParams(ModelSpec):
+    """SABR parameters for Hagan's lognormal implied-vol approximation."""
+
+    alpha: float
+    beta: float
+    rho: float
+    nu: float
+
+    def __init__(self, alpha: float, beta: float, rho: float, nu: float):
+        if not (np.isfinite(alpha) and alpha > 0.0):
+            raise ValueError(f"SabrParams: alpha must be finite and > 0; got {alpha}")
+        if not (np.isfinite(beta) and 0.0 <= beta <= 1.0):
+            raise ValueError(f"SabrParams: beta must be in [0, 1]; got {beta}")
+        if not (np.isfinite(rho) and -1.0 < rho < 1.0):
+            raise ValueError(f"SabrParams: rho must be in (-1, 1); got {rho}")
+        if not (np.isfinite(nu) and nu >= 0.0):
+            raise ValueError(f"SabrParams: nu must be finite and >= 0; got {nu}")
+        object.__setattr__(self, "name", "sabr")
+        object.__setattr__(self, "alpha", float(alpha))
+        object.__setattr__(self, "beta", float(beta))
+        object.__setattr__(self, "rho", float(rho))
+        object.__setattr__(self, "nu", float(nu))
+
+
+def sabr_hagan_implied_vol(F: float, K, T: float, p: SabrParams):
+    """Hagan et al. lognormal SABR implied volatility approximation."""
+    K_arr = np.asarray(K, dtype=np.float64)
+    if F <= 0.0 or T <= 0.0:
+        raise ValueError("SABR Hagan requires F > 0 and T > 0")
+    if np.any(K_arr <= 0.0):
+        raise ValueError("SABR Hagan requires positive strikes")
+
+    alpha, beta, rho, nu = p.alpha, p.beta, p.rho, p.nu
+    one_minus_beta = 1.0 - beta
+    log_fk = np.log(F / K_arr)
+    fk_beta = (F * K_arr) ** (0.5 * one_minus_beta)
+
+    base = alpha / fk_beta
+    z = (nu / alpha) * fk_beta * log_fk if nu > 0.0 else np.zeros_like(K_arr)
+    sqrt_term = np.sqrt(1.0 - 2.0 * rho * z + z * z)
+    x_z = np.log((sqrt_term + z - rho) / (1.0 - rho))
+    z_over_x = np.empty_like(z)
+    small = np.abs(z) < 1e-8
+    z_over_x[small] = 1.0 - 0.5 * rho * z[small]
+    z_over_x[~small] = z[~small] / x_z[~small]
+
+    log_corr = (
+        1.0 + (one_minus_beta**2 / 24.0) * log_fk**2 + (one_minus_beta**4 / 1920.0) * log_fk**4
+    )
+    time_corr = (
+        1.0
+        + (
+            (one_minus_beta**2 / 24.0) * alpha**2 / ((F * K_arr) ** one_minus_beta)
+            + 0.25 * rho * beta * nu * alpha / fk_beta
+            + ((2.0 - 3.0 * rho**2) / 24.0) * nu**2
+        )
+        * T
+    )
+
+    vol = base * z_over_x * time_corr / log_corr
+    atm = np.isclose(log_fk, 0.0, atol=1e-10)
+    if np.any(atm):
+        f_beta = F**one_minus_beta
+        atm_corr = (
+            1.0
+            + (
+                (one_minus_beta**2 / 24.0) * alpha**2 / (F ** (2.0 * one_minus_beta))
+                + 0.25 * rho * beta * nu * alpha / f_beta
+                + ((2.0 - 3.0 * rho**2) / 24.0) * nu**2
+            )
+            * T
+        )
+        vol = np.asarray(vol)
+        vol[atm] = alpha / f_beta * atm_corr
+    return np.asarray(vol, dtype=np.float64)
+
+
+__all__ = ["SabrParams", "sabr_hagan_implied_vol"]

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -20,7 +20,9 @@ from typing import Any
 
 import numpy as np
 
+from .analytics.bsm_asian import bsm_discrete_geometric_asian
 from .analytics.bsm_barrier import bsm_barrier_price
+from .mc.engine import MCSpec, mc_price
 from .models.base import CharFunc, ForwardSpec
 from .models.registry import MODEL_REGISTRY
 from .pricers.carr_madan import carr_madan_price_at_strikes
@@ -35,7 +37,10 @@ from .pricers.filtered_cos import filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes
 from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_at_strikes
 from .pricers.lewis import lewis_call_prices
+from .pricers.mellin import MELLIN_SUPPORTED_MODELS, mellin_price_at_strikes
 from .pricers.pde_fd import PDEGrid, bsm_pde_fd_price, bsm_pde_fd_price_at_strikes
+from .pricers.proj import proj_european_price_at_strikes
+from .pricers.sabr import sabr_hagan_price_at_strikes
 from .utils.grids import CONVGrid, COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
 from .utils.spectral_filters import COSFilterSpec
 
@@ -240,6 +245,11 @@ def price_strip(
     if method == "pyfeng_fft":
         return _pyfeng_fft_price(model, K, fwd, params, cp=cp)
 
+    if method == "sabr_hagan":
+        if model != "sabr":
+            raise ValueError("method='sabr_hagan' is currently implemented only for model='sabr'")
+        return sabr_hagan_price_at_strikes(fwd, params, K, cp=cp)
+
     if method == "lattice":
         if model != "bsm":
             raise ValueError("method='lattice' is currently implemented only for model='bsm'")
@@ -256,6 +266,23 @@ def price_strip(
     if method == "conv":
         conv_grid = grid if isinstance(grid, CONVGrid) else CONVGrid()
         return np.asarray(conv_price_at_strikes(phi, fwd, conv_grid, K, cp=cp), dtype=np.float64)
+
+    if method == "mellin":
+        if model not in MELLIN_SUPPORTED_MODELS:
+            raise ValueError(
+                f"method='mellin' is currently supported for {sorted(MELLIN_SUPPORTED_MODELS)}"
+            )
+        mellin_grid = grid if isinstance(grid, CONVGrid) else None
+        return mellin_price_at_strikes(phi, fwd, K, cp=cp, grid=mellin_grid)
+
+    if method == "proj":
+        return proj_european_price_at_strikes(
+            phi,
+            fwd,
+            MODEL_REGISTRY[model].cumulants(fwd, params),
+            K,
+            cp=cp,
+        )
 
     if method == "pde_fd":
         if model != "bsm":
@@ -461,7 +488,8 @@ def price_strip(
 
     raise ValueError(
         f"unknown method {method!r}; choose 'cos' | 'cos_improved' | 'cos_filtered' | "
-        "'frft' | 'carr_madan' | 'conv' | 'lattice' | 'pde_fd' | 'pyfeng_fft'"
+        "'frft' | 'carr_madan' | 'conv' | 'mellin' | 'proj' | 'lattice' | "
+        "'pde_fd' | 'sabr_hagan' | 'pyfeng_fft'"
     )
 
 
@@ -605,11 +633,69 @@ def price(
             cp=product.cp,
         )
 
+    if pt == "asian":
+        from .models.base import ForwardSpec as _FwdSpec
+        from .products.asian import AsianOption
+
+        if not isinstance(product, AsianOption):
+            raise TypeError(
+                "price(): product_type='asian' must be represented by "
+                f"AsianOption, got {type(product).__name__!r}"
+            )
+        if model != "bsm":
+            raise NotImplementedError(
+                "Asian pricing is currently implemented only for model='bsm'."
+            )
+        if method == "asian_bsm":
+            if product.average_type != "geometric" or product.strike_type != "fixed":
+                raise NotImplementedError(
+                    "method='asian_bsm' currently supports fixed-strike geometric Asians only."
+                )
+            return bsm_discrete_geometric_asian(
+                fwd.S0,
+                product.strike,
+                fwd.r,
+                fwd.q,
+                product.monitoring_times,
+                params.sigma,
+                cp=product.cp,
+            )
+        if method == "asian_mc":
+            mc_spec = grid if isinstance(grid, MCSpec) else MCSpec()
+            fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
+            return mc_price(fwd_t, params.sigma, product, mc_spec).price
+        raise NotImplementedError(
+            "Asian pricing currently supports method='asian_bsm' or method='asian_mc'."
+        )
+
+    if pt == "double_barrier":
+        from .models.base import ForwardSpec as _FwdSpec
+        from .products.barrier import DoubleBarrierOption
+
+        if not isinstance(product, DoubleBarrierOption):
+            raise TypeError(
+                "price(): product_type='double_barrier' must be represented by "
+                f"DoubleBarrierOption, got {type(product).__name__!r}"
+            )
+        if method != "double_barrier_mc":
+            raise NotImplementedError(
+                "Double-barrier pricing currently supports method='double_barrier_mc'."
+            )
+        if model != "bsm":
+            raise NotImplementedError(
+                "method='double_barrier_mc' is currently implemented only for model='bsm'."
+            )
+        if product.rebate != 0.0:
+            raise NotImplementedError("double_barrier_mc currently supports only zero rebates.")
+        mc_spec = grid if isinstance(grid, MCSpec) else MCSpec()
+        fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
+        return mc_price(fwd_t, params.sigma, product, mc_spec).price
+
     # For future products, provide a capability hint instead of a bare NotImplementedError.
     _HINTS: dict[str, str] = {
         "digital": "Use a COS digital pricer (Phase 4.1) or analytic BSM.",
         "barrier": "Use barrier_bsm for continuous zero-rebate BSM barriers.",
-        "asian": "Use asian_geometric_bsm / asian_mc / asian_proj (Phase 4.3).",
+        "asian": "Use asian_bsm for geometric Asians or asian_mc for BSM Monte Carlo.",
         "bermudan": "Use cos_bermudan for Lévy models (Phase 3.3).",
         "american": "Use american_lattice / american_pde (Phase 4.4).",
         "lookback": "Use lookback_bsm / lookback_mc (Phase 4.5).",
@@ -621,7 +707,7 @@ def price(
         "basket": "Use multi_asset_mc (Phase 4.11).",
         "spread": "Use multi_asset_mc / Kirk approximation (Phase 4.11).",
         "best_of": "Use multi_asset_mc (Phase 4.11).",
-        "double_barrier": "Use barrier_mc / barrier_proj (Phase 4.2).",
+        "double_barrier": "Use double_barrier_mc for BSM Monte Carlo double barriers.",
     }
     hint = _HINTS.get(pt, f"No pricer is registered for product_type={pt!r}.")
     raise NotImplementedError(f"price(): product_type={pt!r} is not yet implemented.\n{hint}")

--- a/foureng/pricers/mellin.py
+++ b/foureng/pricers/mellin.py
@@ -1,0 +1,35 @@
+"""Mellin-method European pricing façade.
+
+The MATLAB reference project has model-specific Mellin transform files for VG,
+NIG, FMLS, NTS, and bilateral gamma.  This first slice exposes a stable
+European ``mellin`` method label for those model families and prices through
+the same damped probability-inversion interface used for European transform
+validation.  Model-specific Mellin contour formulae can replace this backend
+incrementally without changing public dispatch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from foureng.models.base import CharFunc, ForwardSpec
+from foureng.pricers.conv import conv_price_at_strikes
+from foureng.utils.grids import CONVGrid
+
+MELLIN_SUPPORTED_MODELS = frozenset({"vg", "nig", "fmls", "bilateral_gamma"})
+
+
+def mellin_price_at_strikes(
+    phi: CharFunc,
+    fwd: ForwardSpec,
+    strikes,
+    *,
+    cp: int = 1,
+    grid: CONVGrid | None = None,
+) -> np.ndarray:
+    """Price European options through the Mellin-method public façade."""
+    conv_grid = grid or CONVGrid(N=4096, u_max=200.0)
+    return np.asarray(conv_price_at_strikes(phi, fwd, conv_grid, strikes, cp=cp), dtype=np.float64)
+
+
+__all__ = ["MELLIN_SUPPORTED_MODELS", "mellin_price_at_strikes"]

--- a/foureng/pricers/proj.py
+++ b/foureng/pricers/proj.py
@@ -1,0 +1,40 @@
+"""First European PROJ-method façade.
+
+This module intentionally implements the smallest stable public slice of the
+MATLAB PROJ surface: European vanilla pricing under one-dimensional CF models.
+The numerical core is currently COS-based, which gives a validated projection
+baseline while reserving the ``proj`` method label for later B-spline/frame
+projection recursions for barriers, Asians, and Bermudans.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from foureng.models.base import CharFunc, ForwardSpec
+from foureng.pricers.cos import cos_auto_grid, cos_prices
+
+
+def proj_european_price_at_strikes(
+    phi: CharFunc,
+    fwd: ForwardSpec,
+    cumulants: tuple[float, float, float],
+    strikes,
+    *,
+    cp: int = 1,
+    N: int = 512,
+    L: float = 10.0,
+) -> np.ndarray:
+    """European vanilla PROJ façade, currently using COS projection coefficients."""
+    if cp not in (1, -1):
+        raise ValueError(f"cp must be +1 or -1, got {cp}")
+    K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    grid = cos_auto_grid(cumulants, N=N, L=L)
+    calls = cos_prices(phi, fwd, K, grid).call_prices
+    if cp == 1:
+        return np.asarray(calls, dtype=np.float64)
+    puts = calls - fwd.disc * (fwd.F0 - K)
+    return np.asarray(np.maximum(puts, 0.0), dtype=np.float64)
+
+
+__all__ = ["proj_european_price_at_strikes"]

--- a/foureng/pricers/sabr.py
+++ b/foureng/pricers/sabr.py
@@ -1,0 +1,34 @@
+"""SABR approximation pricers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from foureng.iv.implied_vol import BSInputs, bs_price_from_fwd
+from foureng.models.base import ForwardSpec
+from foureng.models.sabr import SabrParams, sabr_hagan_implied_vol
+
+
+def sabr_hagan_price_at_strikes(
+    fwd: ForwardSpec,
+    params: SabrParams,
+    strikes,
+    *,
+    cp: int = 1,
+) -> np.ndarray:
+    """Price European options by Hagan SABR implied vol plus Black formula."""
+    if cp not in (1, -1):
+        raise ValueError(f"cp must be +1 or -1, got {cp}")
+    K = np.ascontiguousarray(np.asarray(strikes, dtype=np.float64))
+    vols = sabr_hagan_implied_vol(fwd.F0, K, fwd.T, params)
+    prices = [
+        bs_price_from_fwd(
+            float(vol),
+            BSInputs(fwd.F0, float(k), fwd.T, fwd.r, fwd.q, is_call=(cp == 1)),
+        )
+        for vol, k in zip(vols, K)
+    ]
+    return np.asarray(prices, dtype=np.float64)
+
+
+__all__ = ["sabr_hagan_price_at_strikes"]

--- a/tests/features/test_sprints_1_5_expansion.py
+++ b/tests/features/test_sprints_1_5_expansion.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import foureng as fe
+from foureng.pipeline import price
+from foureng.products import AsianOption, DoubleBarrierOption
+
+
+def test_discrete_geometric_asian_dispatch_matches_public_formula():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=2.0)
+    params = fe.BsmParams(sigma=0.2)
+    times = np.array([0.25, 0.5, 0.75, 1.0])
+    product = AsianOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=1,
+        average_type="geometric",
+        monitoring_times=times,
+    )
+
+    actual = price(product, "bsm", "asian_bsm", fwd, params)
+    expected = fe.bsm_discrete_geometric_asian(
+        fwd.S0, product.strike, fwd.r, fwd.q, times, params.sigma, cp=1
+    )
+
+    assert actual == expected
+
+
+def test_asian_mc_geometric_agrees_with_exact_within_confidence_band():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.03, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.18)
+    times = np.linspace(1.0 / 12.0, 1.0, 12)
+    product = AsianOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=1,
+        average_type="geometric",
+        monitoring_times=times,
+    )
+    mc = fe.MCSpec(n_paths=40_000, n_steps=12, seed=123, antithetic=True)
+
+    actual = price(product, "bsm", "asian_mc", fwd, params, grid=mc)
+    expected = fe.bsm_discrete_geometric_asian(
+        fwd.S0, product.strike, fwd.r, fwd.q, times, params.sigma, cp=1
+    )
+
+    assert abs(actual - expected) < 0.08
+
+
+def test_double_barrier_mc_in_out_parity_on_same_seed():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.02, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    mc = fe.MCSpec(n_paths=30_000, n_steps=80, seed=7, antithetic=True)
+    out_product = DoubleBarrierOption(
+        strike=100.0,
+        lower_barrier=70.0,
+        upper_barrier=140.0,
+        maturity=1.0,
+        cp=1,
+        knockout=True,
+    )
+    in_product = DoubleBarrierOption(
+        strike=100.0,
+        lower_barrier=70.0,
+        upper_barrier=140.0,
+        maturity=1.0,
+        cp=1,
+        knockout=False,
+    )
+    out_price = price(out_product, "bsm", "double_barrier_mc", fwd, params, grid=mc)
+    in_price = price(in_product, "bsm", "double_barrier_mc", fwd, params, grid=mc)
+    vanilla = fe.bs_price_from_fwd(
+        params.sigma,
+        fe.BSInputs(fwd.F0, out_product.strike, fwd.T, fwd.r, fwd.q),
+    )
+
+    assert out_price >= 0.0
+    assert in_price >= 0.0
+    assert_allclose(out_price + in_price, vanilla, atol=0.25, rtol=0.02)
+
+
+def test_proj_european_matches_cos_baseline_for_bsm():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.03, q=0.01, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    strikes = np.array([90.0, 100.0, 110.0])
+
+    proj = fe.price_strip("bsm", "proj", strikes, fwd, params)
+    cos = fe.price_strip("bsm", "cos", strikes, fwd, params, grid=fe.COSGrid(N=512, a=-2.0, b=2.0))
+
+    assert_allclose(proj, cos, atol=2e-4, rtol=2e-5)
+
+
+def test_mellin_facade_matches_conv_for_vg():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.01, q=0.0, T=0.75)
+    params = fe.VGParams(sigma=0.12, nu=0.2, theta=-0.1)
+    strikes = np.array([90.0, 100.0, 110.0])
+    grid = fe.CONVGrid(N=4096, u_max=180.0)
+
+    mellin = fe.price_strip("vg", "mellin", strikes, fwd, params, grid=grid)
+    conv = fe.price_strip("vg", "conv", strikes, fwd, params, grid=grid)
+
+    assert_allclose(mellin, conv, atol=1e-12, rtol=1e-12)
+
+
+def test_sabr_hagan_beta_one_zero_nu_reduces_to_bsm():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.02, q=0.0, T=1.0)
+    params = fe.SabrParams(alpha=0.2, beta=1.0, rho=-0.3, nu=0.0)
+    strikes = np.array([90.0, 100.0, 110.0])
+
+    sabr = fe.price_strip("sabr", "sabr_hagan", strikes, fwd, params)
+    bsm = np.array(
+        [
+            fe.bs_price_from_fwd(0.2, fe.BSInputs(fwd.F0, float(k), fwd.T, fwd.r, fwd.q))
+            for k in strikes
+        ]
+    )
+
+    assert_allclose(sabr, bsm, atol=1e-10, rtol=1e-10)

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -15,6 +15,12 @@ _BASELINE_METHODS = {
     "pyfeng_fft",
     "conv",
     "barrier_bsm",
+    "asian_bsm",
+    "asian_mc",
+    "double_barrier_mc",
+    "mellin",
+    "proj",
+    "sabr_hagan",
 }
 
 _PLANNED_METHODS = {
@@ -22,7 +28,6 @@ _PLANNED_METHODS = {
     "monte_carlo",
     "pde_fd",
     "lattice",
-    "proj",
     "ctmc",
 }
 
@@ -53,7 +58,17 @@ def test_every_method_supports_at_least_one_exercise_style():
 
 
 def test_cf_methods_require_cf():
-    cf_methods = {"cos", "cos_improved", "cos_filtered", "carr_madan", "frft", "pyfeng_fft", "conv"}
+    cf_methods = {
+        "cos",
+        "cos_improved",
+        "cos_filtered",
+        "carr_madan",
+        "frft",
+        "pyfeng_fft",
+        "conv",
+        "mellin",
+        "proj",
+    }
     for m in cf_methods:
         assert METHOD_REGISTRY[m].requires_cf is True, f"{m!r}: requires_cf should be True"
 


### PR DESCRIPTION
## Summary
- add BSM Asian geometric closed form plus Asian Monte Carlo dispatch
- add BSM double-barrier Monte Carlo dispatch
- add SABR Hagan implied-vol pricing
- add first-slice European PROJ and Mellin method facades
- update capability metadata, README/API docs, and focused tests

## Local verification
- ruff format --check foureng/ tests/
- ruff check foureng/ tests/
- python -m pytest -q tests/meta/test_method_registry.py tests/meta/test_capability_matrix.py tests/meta/test_api_snapshot.py tests/features/test_sprints_1_5_expansion.py
- python -m pytest -q -m "not slow"