### PR TITLE
Wire Bermudan COS through product dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 |----------|------------|---------|
 | `price_strip(model, method, strikes, fwd, params, grid=None)` | model label, method label, strike array, `ForwardSpec`, model params, optional grid | `np.ndarray` of call prices |
 
-Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` and SABR-only `"sabr_hagan"`.
+Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"cos_bermudan"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` and SABR-only `"sabr_hagan"`.
 
-Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, and BSM double barriers via `"double_barrier_mc"`.
+Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, supported 1-D Levy Bermudans via `"cos_bermudan"`, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, and BSM double barriers via `"double_barrier_mc"`.
 
 ### Core pricing functions
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -118,6 +118,8 @@ from foureng.pipeline import price, price_strip
 | `carr_madan_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FFTGrid`, strike array | NumPy array of call prices. |
 | `frft_price_at_strikes(phi, fwd, grid, strikes)` | CF, `ForwardSpec`, `FRFTGrid`, strike array | NumPy array of call prices. |
 | `conv_price_at_strikes(phi, fwd, grid, strikes, cp=...)` | CF, `ForwardSpec`, `CONVGrid`, strike array | NumPy array of call or put prices. |
+| `cos_bermudan_price(model, fwd, params, product, grid=...)` | model key, market inputs, params, `BermudanOption` | Scalar Bermudan COS price for supported 1-D Levy models. |
+| `cos_bermudan_price_strip(model, fwd, params, strikes, maturity, exercise_times, cp=...)` | model key, market inputs, params, strike array | Bermudan COS strip for supported 1-D Levy models. |
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=...)` | CF, `ForwardSpec`, strike array, grid, filter | `COSResult` with spectral filtering applied. |
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American CRR tree prices. |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
@@ -138,6 +140,7 @@ from foureng.pipeline import price, price_strip
 | `"carr_madan"` | Carr-Madan FFT |
 | `"frft"` | Fractional FFT |
 | `"conv"` | CONV-style Fourier probability inversion |
+| `"cos_bermudan"` | COS Bermudan backward induction for supported 1-D Levy models |
 | `"mellin"` | First-slice Mellin European façade for VG, NIG, FMLS, bilateral gamma |
 | `"proj"` | First-slice European PROJ façade using COS projection coefficients |
 | `"cos_filtered"` | COS with spectral damping (Fejér, Lanczos, raised-cosine, or exponential filter) |
@@ -153,6 +156,7 @@ from foureng.pipeline import price, price_strip
 |---------|---------------------|-------|
 | `EuropeanOption` | all compatible `price_strip` methods | Vanilla call/put. |
 | `AmericanOption` | `"lattice"`, `"pde_fd"` | BSM call/put. |
+| `BermudanOption` | `"cos_bermudan"` | Supported 1-D Levy call/put with discrete exercise dates. |
 | `BarrierOption` | `"barrier_bsm"` | Continuously monitored, zero-rebate, single-barrier BSM knock-in/knock-out call/put. |
 | `AsianOption` | `"asian_bsm"`, `"asian_mc"` | BSM fixed-strike geometric closed form or BSM arithmetic/geometric Monte Carlo. |
 | `DoubleBarrierOption` | `"double_barrier_mc"` | BSM zero-rebate double knock-in/knock-out Monte Carlo. |

--- a/foureng/__init__.py
+++ b/foureng/__init__.py
@@ -101,6 +101,7 @@ from .pricers.cos import (
     cos_prices,
     recommended_cos_policy,
 )
+from .pricers.cos_bermudan import cos_bermudan_price, cos_bermudan_price_strip
 from .pricers.cos_digital import cos_digital_price, cos_digital_price_strip
 from .pricers.filtered_cos import FilteredCOSDecision, filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes, frft_prices
@@ -216,6 +217,8 @@ __all__ = [
     "carr_madan_price_at_strikes",
     "carr_madan_fft_prices",
     "conv_price_at_strikes",
+    "cos_bermudan_price",
+    "cos_bermudan_price_strip",
     "frft_price_at_strikes",
     "frft_prices",
     "lewis_call_prices",

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -178,6 +178,17 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
         supports_path_dependent=True,
         notes="BSM Monte Carlo double-barrier knock-in/knock-out pricer with zero rebate.",
     ),
+    "cos_bermudan": MethodSpec(
+        requires_cf=True,
+        supports_products=frozenset({"bermudan", "european"}),
+        supports_exercise=frozenset({"european", "bermudan"}),
+        supports_path_dependent=False,
+        notes=(
+            "COS Bermudan via Fang & Oosterlee (2009) backward induction. "
+            "Implemented for supported 1-D Levy models; stochastic-volatility "
+            "extensions remain out of scope."
+        ),
+    ),
     "proj": MethodSpec(
         requires_cf=True,
         supports_products=frozenset({"european"}),
@@ -190,17 +201,6 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
         ),
     ),
     # ── Planned methods (not yet implemented) ────────────────────────────
-    "cos_bermudan": MethodSpec(
-        requires_cf=True,
-        supports_products=frozenset({"bermudan", "european"}),
-        supports_exercise=frozenset({"european", "bermudan"}),
-        supports_path_dependent=False,
-        notes=(
-            "COS Bermudan via Fang & Oosterlee (2009) backward induction. "
-            "Supported for 1-D Lévy models (BSM, VG, CGMY, Kou, Merton JD). "
-            "NOT available for Heston without the 2-D state extension."
-        ),
-    ),
     "monte_carlo": MethodSpec(
         requires_cf=False,
         requires_simulation=True,

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -33,6 +33,7 @@ from .pricers.cos import (
     cos_prices,
     recommended_cos_policy,
 )
+from .pricers.cos_bermudan import cos_bermudan_price
 from .pricers.filtered_cos import filtered_cos_prices
 from .pricers.frft import frft_price_at_strikes
 from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_at_strikes
@@ -509,10 +510,9 @@ def price(
 ) -> float | np.ndarray:
     """Price a :class:`~foureng.products.ProductSpec` under the given model and method.
 
-    This is the product-aware counterpart to :func:`price_strip`.  Currently
-    only :class:`~foureng.products.EuropeanOption` is routed; all other product
-    types raise :class:`NotImplementedError` with an informative message
-    (including which engine would be needed once that product is implemented).
+    This is the product-aware counterpart to :func:`price_strip`. It routes
+    vanilla Europeans plus the currently implemented product-specific engines
+    for American, barrier, Asian, double-barrier, and Bermudan contracts.
 
     Parameters
     ----------
@@ -597,6 +597,18 @@ def price(
         raise NotImplementedError(
             "American pricing currently supports method='lattice' or method='pde_fd'."
         )
+
+    if pt == "bermudan":
+        from .products.bermudan import BermudanOption
+
+        if not isinstance(product, BermudanOption):
+            raise TypeError(
+                "price(): product_type='bermudan' must be represented by "
+                f"BermudanOption, got {type(product).__name__!r}"
+            )
+        if method != "cos_bermudan":
+            raise NotImplementedError("Bermudan pricing currently supports method='cos_bermudan'.")
+        return cos_bermudan_price(model, fwd, params, product, grid=grid)
 
     if pt == "barrier":
         from .products.barrier import BarrierOption
@@ -696,7 +708,7 @@ def price(
         "digital": "Use a COS digital pricer (Phase 4.1) or analytic BSM.",
         "barrier": "Use barrier_bsm for continuous zero-rebate BSM barriers.",
         "asian": "Use asian_bsm for geometric Asians or asian_mc for BSM Monte Carlo.",
-        "bermudan": "Use cos_bermudan for Lévy models (Phase 3.3).",
+        "bermudan": "Use cos_bermudan for supported 1-D Levy models.",
         "american": "Use american_lattice / american_pde (Phase 4.4).",
         "lookback": "Use lookback_bsm / lookback_mc (Phase 4.5).",
         "forward_start": "Use forward_start_bsm / forward_start_mc (Phase 4.6).",

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -18,13 +18,13 @@ _BASELINE_METHODS = {
     "asian_bsm",
     "asian_mc",
     "double_barrier_mc",
+    "cos_bermudan",
     "mellin",
     "proj",
     "sabr_hagan",
 }
 
 _PLANNED_METHODS = {
-    "cos_bermudan",
     "monte_carlo",
     "pde_fd",
     "lattice",
@@ -66,6 +66,7 @@ def test_cf_methods_require_cf():
         "frft",
         "pyfeng_fft",
         "conv",
+        "cos_bermudan",
         "mellin",
         "proj",
     }

--- a/tests/products/test_bermudan_price_dispatch.py
+++ b/tests/products/test_bermudan_price_dispatch.py
@@ -1,0 +1,71 @@
+"""Product-dispatch tests for Bermudan pricing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import foureng as fe
+from foureng.pipeline import price
+from foureng.pricers.cos_bermudan import cos_bermudan_price
+from foureng.products import BermudanOption
+
+
+def test_price_dispatches_to_cos_bermudan_for_bsm():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = BermudanOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=-1,
+        exercise_times=np.linspace(0.25, 1.0, 4),
+    )
+
+    actual = price(product, "bsm", "cos_bermudan", fwd, params)
+    expected = cos_bermudan_price("bsm", fwd, params, product)
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_price_dispatches_to_cos_bermudan_for_vg():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.VGParams(sigma=0.12, nu=0.3, theta=-0.14)
+    product = BermudanOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=-1,
+        exercise_times=np.linspace(0.25, 1.0, 4),
+    )
+
+    actual = price(product, "vg", "cos_bermudan", fwd, params)
+    expected = cos_bermudan_price("vg", fwd, params, product)
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_price_bermudan_rejects_wrong_method():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = BermudanOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=-1,
+        exercise_times=np.linspace(0.25, 1.0, 4),
+    )
+
+    with pytest.raises(NotImplementedError, match="cos_bermudan"):
+        price(product, "bsm", "cos", fwd, params)
+
+
+def test_price_bermudan_rejects_sv_model_with_clear_error():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.5, rho=-0.5, v0=0.04)
+    product = BermudanOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=-1,
+        exercise_times=np.linspace(0.25, 1.0, 4),
+    )
+
+    with pytest.raises(NotImplementedError, match="1-D COS Bermudan"):
+        price(product, "heston", "cos_bermudan", fwd, params)


### PR DESCRIPTION
## Summary
- route  through 
- promote  from planned-only metadata into the baseline implemented surface
- export Bermudan COS helpers and update README/API docs
- add product-dispatch coverage for BSM, VG, wrong-method, and unsupported-SV cases

## Local verification
- ruff check foureng/ tests/
- python -m pytest -q tests/products/test_bermudan_price_dispatch.py tests/methods/test_bermudan_bsm_fo2009.py tests/methods/test_bermudan_levy_consistency.py tests/meta/test_method_registry.py tests/meta/test_capability_matrix.py tests/meta/test_unsupported_combinations_fail_clearly.py
- python -m pytest -q -m "not slow"