### PR TITLE
Add analytic BSM forward-start and lookback dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 |----------|------------|---------|
 | `price_strip(model, method, strikes, fwd, params, grid=None)` | model label, method label, strike array, `ForwardSpec`, model params, optional grid | `np.ndarray` of call prices |
 
-Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"cos_bermudan"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` and SABR-only `"sabr_hagan"`.
+Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"cos_bermudan"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` / `"forward_start_bsm"` / `"lookback_bsm"` and SABR-only `"sabr_hagan"`.
 
-Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, supported 1-D Levy Bermudans via `"cos_bermudan"`, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, and BSM double barriers via `"double_barrier_mc"`.
+Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, supported 1-D Levy Bermudans via `"cos_bermudan"`, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, BSM forward-start options via `"forward_start_bsm"`, continuous floating-strike BSM lookbacks via `"lookback_bsm"`, and BSM double barriers via `"double_barrier_mc"`.
 
 ### Core pricing functions
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -125,6 +125,8 @@ from foureng.pipeline import price, price_strip
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
 | `bsm_barrier_price(S, K, H, r, q, T, sigma, barrier_type, cp=...)` | BSM single-barrier inputs | Closed-form continuous zero-rebate barrier price. |
 | `bsm_discrete_geometric_asian(S, K, r, q, monitoring_times, sigma, cp=...)` | BSM geometric-average inputs | Closed-form discretely monitored geometric Asian price. |
+| `bsm_forward_start(S, alpha, t_start, T, r, q, sigma, cp=...)` | BSM forward-start inputs | Closed-form forward-start price. |
+| `bsm_lookback_floating(S, S_min, S_max, r, q, T, sigma, cp=...)` | BSM floating-lookback inputs | Closed-form continuous floating-strike lookback price. |
 | `proj_european_price_at_strikes(phi, fwd, cumulants, strikes, cp=...)` | CF, market inputs, cumulants, strikes | First-slice European PROJ façade using COS projection coefficients. |
 | `mellin_price_at_strikes(phi, fwd, strikes, cp=...)` | CF, market inputs, strikes | First-slice European Mellin façade for selected Lévy models. |
 | `sabr_hagan_price_at_strikes(fwd, params, strikes, cp=...)` | `ForwardSpec`, `SabrParams`, strikes | Hagan SABR implied-vol prices. |
@@ -148,6 +150,8 @@ from foureng.pipeline import price, price_strip
 | `"lattice"` | BSM-only CRR lattice for European strips |
 | `"pde_fd"` | BSM-only implicit finite-difference solver for European strips |
 | `"barrier_bsm"` | BSM-only analytic single-barrier pricing through `price()` |
+| `"forward_start_bsm"` | BSM-only analytic forward-start pricing through `price()` |
+| `"lookback_bsm"` | BSM-only analytic continuous floating-strike lookback pricing through `price()` |
 | `"sabr_hagan"` | SABR-only Hagan implied-vol approximation for European strips |
 
 ### Product-level dispatcher
@@ -159,6 +163,8 @@ from foureng.pipeline import price, price_strip
 | `BermudanOption` | `"cos_bermudan"` | Supported 1-D Levy call/put with discrete exercise dates. |
 | `BarrierOption` | `"barrier_bsm"` | Continuously monitored, zero-rebate, single-barrier BSM knock-in/knock-out call/put. |
 | `AsianOption` | `"asian_bsm"`, `"asian_mc"` | BSM fixed-strike geometric closed form or BSM arithmetic/geometric Monte Carlo. |
+| `ForwardStartOption` | `"forward_start_bsm"` | BSM forward-start call/put with strike set at `alpha * S_{t_start}`. |
+| `LookbackOption` | `"lookback_bsm"` | BSM continuous floating-strike lookback call/put priced from inception. |
 | `DoubleBarrierOption` | `"double_barrier_mc"` | BSM zero-rebate double knock-in/knock-out Monte Carlo. |
 
 ---

--- a/docs/current_capability_snapshot.md
+++ b/docs/current_capability_snapshot.md
@@ -45,6 +45,8 @@ This file is the reference point for all capability-gate tests.
 | `asian_bsm` | BSM discrete geometric Asian closed form | Kemna-Vorst style lognormal average |
 | `asian_mc` | BSM Asian Monte Carlo | GBM path simulation |
 | `double_barrier_mc` | BSM double-barrier Monte Carlo | GBM path simulation |
+| `forward_start_bsm` | BSM analytic forward-start option | Rubinstein-style forward-start closed form |
+| `lookback_bsm` | BSM analytic floating-strike lookback | Goldman-Sosin-Gatto closed form |
 | `proj` | First-slice European PROJ façade | COS-backed projection baseline |
 | `mellin` | First-slice European Mellin façade | Mellin-transform expansion target |
 | `sabr_hagan` | SABR Hagan approximation | Hagan et al. |
@@ -55,6 +57,8 @@ This file is the reference point for all capability-gate tests.
 - American BSM call / put (via `price(..., method="lattice"|"pde_fd")`)
 - Continuous zero-rebate BSM single-barrier call / put (via `price(..., method="barrier_bsm")`)
 - BSM Asian options (geometric closed form via `asian_bsm`; arithmetic/geometric MC via `asian_mc`)
+- BSM forward-start call / put (via `price(..., method="forward_start_bsm")`)
+- BSM continuous floating-strike lookback call / put (via `price(..., method="lookback_bsm")`)
 - BSM zero-rebate double-barrier options (via `double_barrier_mc`)
 - SABR European call / put strips (via `price_strip("sabr", "sabr_hagan", ...)`)
 

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -178,6 +178,23 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
         supports_path_dependent=True,
         notes="BSM Monte Carlo double-barrier knock-in/knock-out pricer with zero rebate.",
     ),
+    "forward_start_bsm": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"forward_start"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes="Closed-form BSM forward-start pricer with strike set to alpha * S_tstart.",
+    ),
+    "lookback_bsm": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"lookback"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=True,
+        notes=(
+            "Closed-form BSM floating-strike lookback pricer for continuous monitoring "
+            "at inception."
+        ),
+    ),
     "cos_bermudan": MethodSpec(
         requires_cf=True,
         supports_products=frozenset({"bermudan", "european"}),
@@ -430,5 +447,16 @@ def _model_restriction(model: str, product: str, method: str) -> str:
                 f"model={model!r} is not backed by a PyFENG FFT pricer. "
                 f"Use 'cos', 'cos_improved', 'frft', or 'carr_madan'."
             )
+
+    if method in {
+        "barrier_bsm",
+        "asian_bsm",
+        "asian_mc",
+        "double_barrier_mc",
+        "forward_start_bsm",
+        "lookback_bsm",
+    }:
+        if model != "bsm":
+            return f"method={method!r} is currently implemented only for model='bsm'."
 
     return ""

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from .analytics.bsm_asian import bsm_discrete_geometric_asian
 from .analytics.bsm_barrier import bsm_barrier_price
+from .analytics.bsm_exotics import bsm_forward_start, bsm_lookback_floating
 from .mc.engine import MCSpec, mc_price
 from .models.base import CharFunc, ForwardSpec
 from .models.registry import MODEL_REGISTRY
@@ -512,7 +513,8 @@ def price(
 
     This is the product-aware counterpart to :func:`price_strip`. It routes
     vanilla Europeans plus the currently implemented product-specific engines
-    for American, barrier, Asian, double-barrier, and Bermudan contracts.
+    for American, barrier, Asian, double-barrier, Bermudan, forward-start,
+    and lookback contracts.
 
     Parameters
     ----------
@@ -703,6 +705,66 @@ def price(
         fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
         return mc_price(fwd_t, params.sigma, product, mc_spec).price
 
+    if pt == "forward_start":
+        from .products.forward_start import ForwardStartOption
+
+        if not isinstance(product, ForwardStartOption):
+            raise TypeError(
+                "price(): product_type='forward_start' must be represented by "
+                f"ForwardStartOption, got {type(product).__name__!r}"
+            )
+        if method != "forward_start_bsm":
+            raise NotImplementedError(
+                "Forward-start pricing currently supports method='forward_start_bsm'."
+            )
+        if model != "bsm":
+            raise NotImplementedError(
+                "method='forward_start_bsm' is currently implemented only for model='bsm'."
+            )
+        return bsm_forward_start(
+            fwd.S0,
+            product.alpha,
+            product.start_time,
+            product.maturity,
+            fwd.r,
+            fwd.q,
+            params.sigma,
+            cp=product.cp,
+        )
+
+    if pt == "lookback":
+        from .products.lookback import LookbackOption
+
+        if not isinstance(product, LookbackOption):
+            raise TypeError(
+                "price(): product_type='lookback' must be represented by "
+                f"LookbackOption, got {type(product).__name__!r}"
+            )
+        if method != "lookback_bsm":
+            raise NotImplementedError("Lookback pricing currently supports method='lookback_bsm'.")
+        if model != "bsm":
+            raise NotImplementedError(
+                "method='lookback_bsm' is currently implemented only for model='bsm'."
+            )
+        if product.monitoring != "continuous":
+            raise NotImplementedError(
+                "method='lookback_bsm' currently supports only continuous monitoring."
+            )
+        if product.strike_type != "floating":
+            raise NotImplementedError(
+                "method='lookback_bsm' currently supports only floating-strike lookbacks."
+            )
+        return bsm_lookback_floating(
+            fwd.S0,
+            S_min=fwd.S0,
+            S_max=fwd.S0,
+            r=fwd.r,
+            q=fwd.q,
+            T=product.maturity,
+            sigma=params.sigma,
+            cp=product.cp,
+        )
+
     # For future products, provide a capability hint instead of a bare NotImplementedError.
     _HINTS: dict[str, str] = {
         "digital": "Use a COS digital pricer (Phase 4.1) or analytic BSM.",
@@ -710,8 +772,8 @@ def price(
         "asian": "Use asian_bsm for geometric Asians or asian_mc for BSM Monte Carlo.",
         "bermudan": "Use cos_bermudan for supported 1-D Levy models.",
         "american": "Use american_lattice / american_pde (Phase 4.4).",
-        "lookback": "Use lookback_bsm / lookback_mc (Phase 4.5).",
-        "forward_start": "Use forward_start_bsm / forward_start_mc (Phase 4.6).",
+        "lookback": "Use lookback_bsm for continuous floating-strike BSM lookbacks.",
+        "forward_start": "Use forward_start_bsm for BSM forward-start options.",
         "variance_swap": "Use variance_analytic_bsm / variance_heston (Phase 4.7).",
         "variance_option": "Use variance_mc (Phase 4.7).",
         "cliquet": "Use cliquet_mc / cliquet_proj (Phase 4.8).",

--- a/tests/meta/test_capability_matrix.py
+++ b/tests/meta/test_capability_matrix.py
@@ -26,6 +26,8 @@ from foureng.core.capabilities import explain_capability
         ("heston", "asian", "monte_carlo"),
         ("bsm", "barrier", "pde_fd"),
         ("bsm", "american", "lattice"),
+        ("bsm", "forward_start", "forward_start_bsm"),
+        ("bsm", "lookback", "lookback_bsm"),
         ("vg", "european", "proj"),
     ],
 )

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -18,6 +18,8 @@ _BASELINE_METHODS = {
     "asian_bsm",
     "asian_mc",
     "double_barrier_mc",
+    "forward_start_bsm",
+    "lookback_bsm",
     "cos_bermudan",
     "mellin",
     "proj",

--- a/tests/meta/test_unsupported_combinations_fail_clearly.py
+++ b/tests/meta/test_unsupported_combinations_fail_clearly.py
@@ -22,6 +22,7 @@ _UNSUPPORTED = [
     ("cgmy", "barrier", "cos"),
     ("bsm", "lookback", "frft"),
     ("heston", "lookback", "carr_madan"),
+    ("vg", "lookback", "lookback_bsm"),
     ("bsm", "variance_swap", "cos"),
     ("bsm", "cliquet", "cos_improved"),
     # COS Bermudan: SV models not supported
@@ -31,6 +32,7 @@ _UNSUPPORTED = [
     ("rough_heston", "bermudan", "cos_bermudan"),
     ("bates", "bermudan", "cos_bermudan"),
     ("heston_kou", "bermudan", "cos_bermudan"),
+    ("heston", "forward_start", "forward_start_bsm"),
     # pyfeng_fft: non-pyfeng models
     ("kou", "european", "pyfeng_fft"),
     ("merton_jd", "european", "pyfeng_fft"),

--- a/tests/products/test_analytic_exotic_price_dispatch.py
+++ b/tests/products/test_analytic_exotic_price_dispatch.py
@@ -1,0 +1,76 @@
+"""Product-dispatch tests for analytic BSM exotics."""
+
+from __future__ import annotations
+
+import pytest
+
+import foureng as fe
+from foureng.pipeline import price
+from foureng.products import ForwardStartOption, LookbackOption
+
+
+def test_price_dispatches_forward_start_bsm():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = ForwardStartOption(start_time=0.5, maturity=1.0, cp=1, alpha=1.0)
+
+    actual = price(product, "bsm", "forward_start_bsm", fwd, params)
+    expected = fe.bsm_forward_start(
+        fwd.S0,
+        product.alpha,
+        product.start_time,
+        product.maturity,
+        fwd.r,
+        fwd.q,
+        params.sigma,
+        cp=product.cp,
+    )
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_price_dispatches_lookback_bsm():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = LookbackOption(maturity=1.0, cp=1, strike_type="floating", monitoring="continuous")
+
+    actual = price(product, "bsm", "lookback_bsm", fwd, params)
+    expected = fe.bsm_lookback_floating(
+        fwd.S0,
+        S_min=fwd.S0,
+        S_max=fwd.S0,
+        r=fwd.r,
+        q=fwd.q,
+        T=product.maturity,
+        sigma=params.sigma,
+        cp=product.cp,
+    )
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_forward_start_dispatch_rejects_non_bsm_model():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.5, rho=-0.5, v0=0.04)
+    product = ForwardStartOption(start_time=0.5, maturity=1.0, cp=1, alpha=1.0)
+
+    with pytest.raises(NotImplementedError, match="only for model='bsm'"):
+        price(product, "heston", "forward_start_bsm", fwd, params)
+
+
+def test_lookback_dispatch_rejects_fixed_strike():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = LookbackOption(maturity=1.0, cp=1, strike_type="fixed", strike=100.0)
+
+    with pytest.raises(NotImplementedError, match="floating-strike"):
+        price(product, "bsm", "lookback_bsm", fwd, params)
+
+
+def test_lookback_dispatch_rejects_discrete_monitoring():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.20)
+    product = LookbackOption(maturity=1.0, cp=1, strike_type="floating", monitoring="discrete")
+
+    with pytest.raises(NotImplementedError, match="continuous monitoring"):
+        price(product, "bsm", "lookback_bsm", fwd, params)


### PR DESCRIPTION
## Summary
- route ForwardStartOption through price(..., method=forward_start_bsm)
- route continuous floating-strike LookbackOption through price(..., method=lookback_bsm)
- add capability metadata and docs for the new BSM-only product methods
- add dispatcher and capability tests for supported and unsupported cases

## Local verification
- ruff check foureng/ tests/
- python -m pytest -q tests/products/test_analytic_exotic_price_dispatch.py tests/analytics/test_bsm_exotics.py tests/meta/test_method_registry.py tests/meta/test_capability_matrix.py tests/meta/test_unsupported_combinations_fail_clearly.py
- python -m pytest -q -m "not slow"