### PR TITLE
Add digital option dispatcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ Full model details: [docs/model_zoo.md](docs/model_zoo.md).
 |----------|------------|---------|
 | `price_strip(model, method, strikes, fwd, params, grid=None)` | model label, method label, strike array, `ForwardSpec`, model params, optional grid | `np.ndarray` of call prices |
 
-Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"cos_bermudan"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus BSM-only `"pde_fd"` / `"lattice"` / `"forward_start_bsm"` / `"lookback_bsm"` / `"lookback_mc"` / `"variance_mc"` / `"cliquet_mc"` and SABR-only `"sabr_hagan"`.
+Method labels: `"cos"`, `"cos_improved"`, `"cos_filtered"`, `"carr_madan"`, `"frft"`, `"conv"`, `"cos_bermudan"`, `"mellin"`, `"proj"`, `"pyfeng_fft"`, plus product-aware `"cos_digital"` / `"digital_bsm"` / `"barrier_bsm"` / `"asian_bsm"` / `"asian_mc"` / `"double_barrier_mc"` / `"forward_start_bsm"` / `"lookback_bsm"` / `"lookback_mc"` / `"variance_mc"` / `"cliquet_mc"` and SABR-only `"sabr_hagan"`.
 
-Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, supported 1-D Levy Bermudans via `"cos_bermudan"`, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, BSM forward-start options via `"forward_start_bsm"`, BSM lookbacks via `"lookback_bsm"` / `"lookback_mc"`, BSM variance swaps and variance options via `"variance_mc"`, BSM cliquets via `"cliquet_mc"`, and BSM double barriers via `"double_barrier_mc"`.
+Product-level pricing uses `price(product, model, method, fwd, params)`. It currently routes European options, cash-or-nothing and asset-or-nothing digitals via `"cos_digital"` or BSM `"digital_bsm"`, supported 1-D Levy Bermudans via `"cos_bermudan"`, BSM American options via `"lattice"` / `"pde_fd"`, continuously monitored zero-rebate BSM single barriers via `"barrier_bsm"`, BSM Asians via `"asian_bsm"` / `"asian_mc"`, BSM forward-start options via `"forward_start_bsm"`, BSM lookbacks via `"lookback_bsm"` / `"lookback_mc"`, BSM variance swaps and variance options via `"variance_mc"`, BSM cliquets via `"cliquet_mc"`, and BSM double barriers via `"double_barrier_mc"`.
 
 ### Core pricing functions
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -120,6 +120,8 @@ from foureng.pipeline import price, price_strip
 | `conv_price_at_strikes(phi, fwd, grid, strikes, cp=...)` | CF, `ForwardSpec`, `CONVGrid`, strike array | NumPy array of call or put prices. |
 | `cos_bermudan_price(model, fwd, params, product, grid=...)` | model key, market inputs, params, `BermudanOption` | Scalar Bermudan COS price for supported 1-D Levy models. |
 | `cos_bermudan_price_strip(model, fwd, params, strikes, maturity, exercise_times, cp=...)` | model key, market inputs, params, strike array | Bermudan COS strip for supported 1-D Levy models. |
+| `cos_digital_price(model, fwd, params, product, grid=...)` | model key, market inputs, params, `DigitalOption` | Scalar COS digital price for cash-or-nothing or asset-or-nothing payoffs. |
+| `cos_digital_price_strip(model, fwd, params, strikes, maturity, cp=...)` | model key, market inputs, params, strike array | COS digital strip at a shared maturity. |
 | `filtered_cos_prices(phi, fwd, strikes, grid, filter_spec=...)` | CF, `ForwardSpec`, strike array, grid, filter | `COSResult` with spectral filtering applied. |
 | `bsm_lattice_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American CRR tree prices. |
 | `bsm_pde_fd_price_at_strikes(fwd, params, strikes, cp=..., exercise=...)` | `ForwardSpec`, `BsmParams`, strike array | BSM European/American finite-difference prices. |
@@ -147,6 +149,8 @@ from foureng.pipeline import price, price_strip
 | `"proj"` | First-slice European PROJ façade using COS projection coefficients |
 | `"cos_filtered"` | COS with spectral damping (Fejér, Lanczos, raised-cosine, or exponential filter) |
 | `"pyfeng_fft"` | PyFENG-backed Lewis-style FFT path (PyFENG-backed models only) |
+| `"cos_digital"` | COS digital pricing through `price()` for `DigitalOption` |
+| `"digital_bsm"` | BSM-only analytic digital pricing through `price()` |
 | `"lattice"` | BSM-only CRR lattice for European strips |
 | `"pde_fd"` | BSM-only implicit finite-difference solver for European strips |
 | `"barrier_bsm"` | BSM-only analytic single-barrier pricing through `price()` |
@@ -162,6 +166,7 @@ from foureng.pipeline import price, price_strip
 | Product | Supported method(s) | Scope |
 |---------|---------------------|-------|
 | `EuropeanOption` | all compatible `price_strip` methods | Vanilla call/put. |
+| `DigitalOption` | `"cos_digital"`, `"digital_bsm"` | Cash-or-nothing or asset-or-nothing digitals; analytic closed form is BSM-only. |
 | `AmericanOption` | `"lattice"`, `"pde_fd"` | BSM call/put. |
 | `BermudanOption` | `"cos_bermudan"` | Supported 1-D Levy call/put with discrete exercise dates. |
 | `BarrierOption` | `"barrier_bsm"` | Continuously monitored, zero-rebate, single-barrier BSM knock-in/knock-out call/put. |

--- a/docs/current_capability_snapshot.md
+++ b/docs/current_capability_snapshot.md
@@ -41,6 +41,8 @@ This file is the reference point for all capability-gate tests.
 | `conv` | CONV-style Fourier probability inversion | Choi/Kirkby MATLAB comparison target |
 | `lattice` | BSM Cox-Ross-Rubinstein tree | Cox, Ross & Rubinstein (1979) |
 | `pde_fd` | BSM implicit finite difference | Black-Scholes PDE |
+| `digital_bsm` | BSM closed-form digital option | Black-Scholes closed form |
+| `cos_digital` | COS digital option pricing | Fang-Oosterlee payoff extension |
 | `barrier_bsm` | BSM closed-form single-barrier option | Reiner-Rubinstein / Haug |
 | `asian_bsm` | BSM discrete geometric Asian closed form | Kemna-Vorst style lognormal average |
 | `asian_mc` | BSM Asian Monte Carlo | GBM path simulation |
@@ -57,6 +59,7 @@ This file is the reference point for all capability-gate tests.
 ## Products supported
 
 - European call / put (via `price_strip`)
+- Digital cash-or-nothing and asset-or-nothing options (via `price(..., method="cos_digital"|"digital_bsm")`)
 - American BSM call / put (via `price(..., method="lattice"|"pde_fd")`)
 - Continuous zero-rebate BSM single-barrier call / put (via `price(..., method="barrier_bsm")`)
 - BSM Asian options (geometric closed form via `asian_bsm`; arithmetic/geometric MC via `asian_mc`)

--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -155,6 +155,20 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
             "zero-rebate knock-in/knock-out calls and puts."
         ),
     ),
+    "digital_bsm": MethodSpec(
+        requires_cf=False,
+        supports_products=frozenset({"digital"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes="Closed-form BSM cash-or-nothing and asset-or-nothing digital pricer.",
+    ),
+    "cos_digital": MethodSpec(
+        requires_cf=True,
+        supports_products=frozenset({"digital"}),
+        supports_exercise=frozenset({"european"}),
+        supports_path_dependent=False,
+        notes="COS digital pricer for cash-or-nothing and asset-or-nothing European digitals.",
+    ),
     "asian_bsm": MethodSpec(
         requires_cf=False,
         supports_products=frozenset({"asian"}),
@@ -474,6 +488,7 @@ def _model_restriction(model: str, product: str, method: str) -> str:
 
     if method in {
         "barrier_bsm",
+        "digital_bsm",
         "asian_bsm",
         "asian_mc",
         "double_barrier_mc",

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -513,8 +513,8 @@ def price(
 
     This is the product-aware counterpart to :func:`price_strip`. It routes
     vanilla Europeans plus the currently implemented product-specific engines
-    for American, barrier, Asian, double-barrier, Bermudan, forward-start,
-    and lookback contracts.
+    for digitals, Americans, barriers, Asians, double-barriers, Bermudans,
+    forward-starts, lookbacks, and selected variance-linked contracts.
 
     Parameters
     ----------
@@ -561,6 +561,38 @@ def price(
             model, method, [product.strike], fwd_t, params, grid=grid, cp=product.cp
         )
         return float(results[0])
+
+    if pt == "digital":
+        from .models.base import ForwardSpec as _FwdSpec
+        from .models.bsm import bsm_asset_or_nothing, bsm_cash_or_nothing
+        from .pricers.cos_digital import cos_digital_price
+        from .products.digital import DigitalOption
+
+        if not isinstance(product, DigitalOption):
+            raise TypeError(
+                "price(): product_type='digital' must be represented by "
+                f"DigitalOption, got {type(product).__name__!r}"
+            )
+        fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
+        if method == "digital_bsm":
+            if model != "bsm":
+                raise NotImplementedError(
+                    "method='digital_bsm' is currently implemented only for model='bsm'."
+                )
+            if product.payoff_type == "cash_or_nothing":
+                return bsm_cash_or_nothing(
+                    fwd_t,
+                    params,
+                    product.strike,
+                    cp=product.cp,
+                    cash_amount=product.cash_amount,
+                )
+            return bsm_asset_or_nothing(fwd_t, params, product.strike, cp=product.cp)
+        if method == "cos_digital":
+            return cos_digital_price(model, fwd_t, params, product, grid=grid)
+        raise NotImplementedError(
+            "Digital pricing currently supports method='digital_bsm' or method='cos_digital'."
+        )
 
     if pt == "american":
         from .models.base import ForwardSpec as _FwdSpec
@@ -835,7 +867,7 @@ def price(
 
     # For future products, provide a capability hint instead of a bare NotImplementedError.
     _HINTS: dict[str, str] = {
-        "digital": "Use a COS digital pricer (Phase 4.1) or analytic BSM.",
+        "digital": "Use method='cos_digital' or method='digital_bsm' for BSM closed form.",
         "barrier": "Use barrier_bsm for continuous zero-rebate BSM barriers.",
         "asian": "Use asian_bsm for geometric Asians or asian_mc for BSM Monte Carlo.",
         "bermudan": "Use cos_bermudan for supported 1-D Levy models.",

--- a/tests/meta/test_capability_matrix.py
+++ b/tests/meta/test_capability_matrix.py
@@ -19,6 +19,8 @@ from foureng.core.capabilities import explain_capability
         ("bsm", "european", "pyfeng_fft"),
         ("heston", "european", "pyfeng_fft"),
         ("bsm", "bermudan", "cos_bermudan"),
+        ("bsm", "digital", "digital_bsm"),
+        ("heston", "digital", "cos_digital"),
         ("vg", "bermudan", "cos_bermudan"),
         ("cgmy", "bermudan", "cos_bermudan"),
         ("kou", "bermudan", "cos_bermudan"),
@@ -56,6 +58,7 @@ def test_supported_combinations_return_supported(model, product, method):
         ("bates", "bermudan", "cos_bermudan"),  # SVJD — not supported
         ("kou", "asian", "cos"),
         ("bsm", "cliquet", "frft"),
+        ("heston", "digital", "digital_bsm"),
     ],
 )
 def test_unsupported_combinations_return_not_supported(model, product, method):
@@ -99,6 +102,11 @@ def test_pyfeng_fft_unsupported_model():
 def test_barrier_cos_suggests_alternatives():
     result = explain_capability("bsm", "barrier", "cos")
     assert any(word in result.lower() for word in ["pde", "lattice", "mc", "monte"])
+
+
+def test_digital_bsm_explanation_mentions_bsm_only():
+    result = explain_capability("heston", "digital", "digital_bsm")
+    assert "model='bsm'" in result
 
 
 # ── Parity: same output regardless of how registry is imported ─────────────

--- a/tests/meta/test_method_registry.py
+++ b/tests/meta/test_method_registry.py
@@ -27,6 +27,8 @@ _BASELINE_METHODS = {
     "mellin",
     "proj",
     "sabr_hagan",
+    "digital_bsm",
+    "cos_digital",
 }
 
 _PLANNED_METHODS = {
@@ -74,6 +76,7 @@ def test_cf_methods_require_cf():
         "cos_bermudan",
         "mellin",
         "proj",
+        "cos_digital",
     }
     for m in cf_methods:
         assert METHOD_REGISTRY[m].requires_cf is True, f"{m!r}: requires_cf should be True"

--- a/tests/meta/test_unsupported_combinations_fail_clearly.py
+++ b/tests/meta/test_unsupported_combinations_fail_clearly.py
@@ -43,6 +43,7 @@ _UNSUPPORTED = [
     ("bilateral_gamma", "european", "pyfeng_fft"),
     ("generalized_hyperbolic", "european", "pyfeng_fft"),
     ("fmls", "european", "pyfeng_fft"),
+    ("heston", "digital", "digital_bsm"),
     # PDE/lattice: CF-only models without state-space
     # (these are 'planned' methods; their specs say they require markov state)
     # The registry still says they support european — so these should be Supported.

--- a/tests/products/test_digital_price_dispatch.py
+++ b/tests/products/test_digital_price_dispatch.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+from pytest import approx
+
+import foureng as fe
+from foureng.models.bsm import bsm_asset_or_nothing, bsm_cash_or_nothing
+from foureng.pipeline import price
+from foureng.pricers.cos_digital import cos_digital_price
+from foureng.products import DigitalOption
+
+
+def test_digital_bsm_dispatch_matches_cash_closed_form():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.02, T=3.0)
+    params = fe.BsmParams(sigma=0.2)
+    product = DigitalOption(
+        strike=100.0,
+        maturity=1.0,
+        cp=1,
+        payoff_type="cash_or_nothing",
+        cash_amount=2.5,
+    )
+
+    actual = price(product, "bsm", "digital_bsm", fwd, params)
+    expected = bsm_cash_or_nothing(
+        fe.ForwardSpec(S0=100.0, r=0.05, q=0.02, T=1.0),
+        params,
+        100.0,
+        cp=1,
+        cash_amount=2.5,
+    )
+
+    assert actual == approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_digital_bsm_dispatch_matches_asset_closed_form():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=2.0)
+    params = fe.BsmParams(sigma=0.22)
+    product = DigitalOption(
+        strike=95.0,
+        maturity=0.75,
+        cp=-1,
+        payoff_type="asset_or_nothing",
+    )
+
+    actual = price(product, "bsm", "digital_bsm", fwd, params)
+    expected = bsm_asset_or_nothing(
+        fe.ForwardSpec(S0=100.0, r=0.04, q=0.01, T=0.75),
+        params,
+        95.0,
+        cp=-1,
+    )
+
+    assert actual == approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_cos_digital_dispatch_matches_public_pricer_for_non_bsm_model():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.03, q=0.01, T=4.0)
+    params = fe.VGParams(sigma=0.12, nu=0.2, theta=-0.1)
+    product = DigitalOption(
+        strike=105.0,
+        maturity=0.5,
+        cp=1,
+        payoff_type="cash_or_nothing",
+    )
+
+    actual = price(product, "vg", "cos_digital", fwd, params)
+    expected = cos_digital_price(
+        "vg",
+        fe.ForwardSpec(S0=100.0, r=0.03, q=0.01, T=0.5),
+        params,
+        product,
+    )
+
+    assert actual == approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_digital_bsm_rejects_non_bsm_model():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.3, rho=-0.5, v0=0.04)
+    product = DigitalOption(strike=100.0, maturity=1.0, cp=1)
+
+    with pytest.raises(NotImplementedError, match="model='bsm'"):
+        price(product, "heston", "digital_bsm", fwd, params)
+
+
+def test_digital_unknown_method_is_explicit():
+    fwd = fe.ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    params = fe.BsmParams(sigma=0.2)
+    product = DigitalOption(strike=100.0, maturity=1.0, cp=1)
+
+    with pytest.raises(NotImplementedError, match="digital_bsm") as exc_info:
+        price(product, "bsm", "cos", fwd, params)
+    assert "cos_digital" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- wire `DigitalOption` through `price(...)` with `digital_bsm` and `cos_digital`
- register both methods in the capability matrix and update API/docs snapshots
- add dispatcher and capability regression tests for the new digital routes

## Verification
- `/tmp/fourier-digital-venv/bin/ruff check foureng tests/products/test_digital_price_dispatch.py tests/meta/test_method_registry.py tests/meta/test_capability_matrix.py tests/meta/test_unsupported_combinations_fail_clearly.py`
- `/tmp/fourier-digital-venv/bin/pytest -q tests/products/test_digital_price_dispatch.py tests/meta/test_method_registry.py tests/meta/test_capability_matrix.py tests/meta/test_unsupported_combinations_fail_clearly.py tests/methods/test_cos_digital.py`
- `/tmp/fourier-digital-venv/bin/pytest -q -m 'not slow'`
- `/tmp/fourier-digital-venv/bin/mypy foureng`
