### PR TITLE
Clean up pipeline dead code + wire PROJ Bermudan into price()

### DIFF
--- a/foureng/core/capabilities.py
+++ b/foureng/core/capabilities.py
@@ -309,15 +309,16 @@ METHOD_REGISTRY: dict[str, MethodSpec] = {
     ),
     "proj": MethodSpec(
         requires_cf=True,
-        supports_products=frozenset({"european"}),
-        supports_exercise=frozenset({"european"}),
+        supports_products=frozenset({"european", "bermudan"}),
+        supports_exercise=frozenset({"european", "bermudan"}),
         supports_path_dependent=False,
         notes=(
             "PROJ / Frame Projection (Kirkby 2015, 2017). Real B-spline frame "
             "projection (Haar/linear/quadratic/cubic) for European vanilla "
             "calls/puts on CF-equipped Lévy models, validated against COS to "
-            "~1e-7. A Bermudan-put recursion (proj_bermudan_put) is available "
-            "directly; further path-dependent exotics are planned."
+            "~1e-7. Bermudan puts on a uniform monitoring grid are priced via "
+            "the PROJ Toeplitz-FFT recursion (proj_bermudan_put) for the same "
+            "1-D Lévy family; further path-dependent exotics are planned."
         ),
     ),
     # ── Planned methods (not yet implemented) ────────────────────────────

--- a/foureng/pipeline.py
+++ b/foureng/pipeline.py
@@ -5,9 +5,6 @@ The main entry points are:
 * :func:`price_strip` — price a vector of strikes for a European option.
 * :func:`price` — price a single :class:`~foureng.products.ProductSpec` object.
 
-The internal phase helpers (phase2_carr_madan, phase3_frft, phase4_cos) are thin
-wrappers used by the demo notebooks; end users will rarely call them directly.
-
 The improved COS path (``method="cos_improved"``) builds the truncation interval
 and cosine-term count adaptively from model cumulants, then routes wide-interval
 cases to Lewis or Carr-Madan rather than forcing COS into an unfavorable geometry.
@@ -15,7 +12,6 @@ cases to Lewis or Carr-Madan rather than forcing COS into an unfavorable geometr
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -29,7 +25,7 @@ from .analytics.bsm_exotics import (
     margrabe_exchange,
 )
 from .mc.engine import MCSpec, mc_price
-from .models.base import CharFunc, ForwardSpec
+from .models.base import ForwardSpec
 from .models.registry import MODEL_REGISTRY
 from .pricers.carr_madan import carr_madan_price_at_strikes
 from .pricers.conv import conv_price_at_strikes
@@ -46,36 +42,10 @@ from .pricers.lattice import LatticeGrid, bsm_lattice_price, bsm_lattice_price_a
 from .pricers.lewis import lewis_call_prices
 from .pricers.mellin import MELLIN_SUPPORTED_MODELS, mellin_price_at_strikes
 from .pricers.pde_fd import PDEGrid, bsm_pde_fd_price, bsm_pde_fd_price_at_strikes
-from .pricers.proj import proj_european_price_at_strikes
+from .pricers.proj import proj_auto_grid, proj_bermudan_put, proj_european_price_at_strikes
 from .pricers.sabr import sabr_hagan_price_at_strikes
-from .utils.grids import CONVGrid, COSGrid, COSGridPolicy, FFTGrid, FRFTGrid
+from .utils.grids import CONVGrid, COSGrid, COSGridPolicy, FFTGrid
 from .utils.spectral_filters import COSFilterSpec
-
-
-@dataclass(frozen=True)
-class PhaseOutputs:
-    strikes: np.ndarray
-    prices: np.ndarray
-
-
-def phase2_carr_madan(
-    phi: CharFunc, fwd: ForwardSpec, strikes: np.ndarray, grid: FFTGrid
-) -> PhaseOutputs:
-    prices = carr_madan_price_at_strikes(phi, fwd, grid, strikes)
-    return PhaseOutputs(strikes=np.asarray(strikes, float), prices=prices)
-
-
-def phase3_frft(
-    phi: CharFunc, fwd: ForwardSpec, strikes: np.ndarray, grid: FRFTGrid
-) -> PhaseOutputs:
-    prices = frft_price_at_strikes(phi, fwd, grid, strikes)
-    return PhaseOutputs(strikes=np.asarray(strikes, float), prices=prices)
-
-
-def phase4_cos(phi: CharFunc, fwd: ForwardSpec, strikes: np.ndarray, grid: COSGrid) -> PhaseOutputs:
-    res = cos_prices(phi, fwd, strikes, grid)
-    return PhaseOutputs(strikes=res.strikes, prices=res.call_prices)
-
 
 # ---------------------------------------------------------------------------
 # Unified strip pricing  -  one call that the notebook / scoreboard goes
@@ -214,32 +184,34 @@ def price_strip(
     Parameters
     ----------
     model :
-        One of the supported model keys: ``"bsm"``, ``"heston"``, ``"ousv"``,
-        ``"vg"``, ``"cgmy"``, ``"nig"``, ``"kou"``, ``"bates"``,
-        ``"heston_kou"``, ``"heston_cgmy"``, ``"sv32"``.
+        Any key in :data:`~foureng.models.registry.MODEL_REGISTRY` (e.g.
+        ``"bsm"``, ``"heston"``, ``"vg"``, ``"cgmy"``, ``"nig"``, ``"kou"`` …),
+        or ``"sabr"`` when ``method="sabr_hagan"``.
     method :
-        * ``"cos"``  -  in-house COS (Fang-Oosterlee 2008),
-        * ``"cos_improved"``  -  adaptive COS policy with centered intervals,
-          coupled N/L selection, and wide-interval fallback,
-        * ``"frft"``  -  in-house FRFT (Chourdakis 2004),
-        * ``"carr_madan"``  -  in-house Carr-Madan FFT (1999),
-        * ``"pyfeng_fft"``  -  PyFENG's own native FFT pricer. Available for:
-          BSM, Heston, OUSV, VG, CGMY, NIG, 3/2 SV (``sv32``), Rough Heston.
-          Not available for Kou, Bates, Heston-Kou, Heston-CGMY, GARCH,
-          Merton JD, Meixner, Bilateral Gamma, GH, or FMLS.
+        Characteristic-function engines:
+        ``"cos"`` / ``"cos_improved"`` / ``"cos_filtered"`` (Fang-Oosterlee 2008
+        and the adaptive/filtered extensions), ``"carr_madan"`` (FFT, 1999),
+        ``"frft"`` (Chourdakis 2004), ``"conv"`` (Fourier inversion),
+        ``"mellin"`` (Mellin transform, selected Lévy models), ``"proj"`` (PROJ
+        frame projection, Kirkby 2015/2017), and ``"pyfeng_fft"`` (PyFENG native
+        FFT for BSM/Heston/OUSV/VG/CGMY/NIG/3-2 SV/Rough Heston).
+        Non-CF baselines: ``"lattice"`` and ``"pde_fd"`` (BSM only),
+        ``"sabr_hagan"`` (``model="sabr"``).
     strikes :
         1-D iterable of strikes.
     fwd, params :
         Forward spec and model-specific parameter dataclass.
     grid :
-        Grid object appropriate to ``method``  -  :class:`FFTGrid` for
-        ``"carr_madan"``, :class:`FRFTGrid` for ``"frft"``,
-        :class:`COSGrid` for ``"cos"``. ``method='cos_improved'`` also accepts
-        :class:`COSGridPolicy`. If ``None`` and ``method='cos'``, an auto grid
-        is built from the model cumulants with :func:`cos_auto_grid`.
+        Grid object appropriate to ``method`` — :class:`FFTGrid` for
+        ``"carr_madan"``, :class:`FRFTGrid` for ``"frft"``, :class:`CONVGrid`
+        for ``"conv"``, :class:`COSGrid` for ``"cos"`` (with
+        :class:`COSGridPolicy` also accepted by ``"cos_improved"`` /
+        ``"cos_filtered"``), :class:`LatticeGrid` / :class:`PDEGrid` for the
+        BSM baselines. If ``None``, a sensible engine-specific grid is built
+        (e.g. ``cos_auto_grid`` / ``proj_auto_grid`` from the model cumulants).
     cp :
-        ``+1`` calls, ``-1`` puts (consulted only by ``pyfeng_fft``; the
-        in-house pricers return calls and the caller applies parity).
+        ``+1`` calls, ``-1`` puts. The CF engines return calls and apply
+        put-call parity internally where needed.
 
     Returns
     -------
@@ -505,6 +477,62 @@ def price_strip(
 # ---------------------------------------------------------------------------
 
 
+def _proj_bermudan_put_price(model: str, fwd: ForwardSpec, params, product) -> float:
+    """PROJ Bermudan **put** for 1-D Lévy models on a uniform monitoring grid.
+
+    Builds the one-step risk-neutral CF from the model registry and drives the
+    PROJ Toeplitz-FFT recursion (:func:`~foureng.pricers.proj.proj_bermudan_put`).
+    Supports the same 1-D Lévy family as ``cos_bermudan``; calls and arbitrary
+    (non-uniform) exercise schedules are deferred to ``method='cos_bermudan'``.
+    """
+    from .pricers.cos_bermudan import _SUPPORTED_MODELS
+
+    if product.cp != -1:
+        raise NotImplementedError(
+            "method='proj' for Bermudans currently supports puts (cp=-1); "
+            "use method='cos_bermudan' for calls."
+        )
+    if model not in _SUPPORTED_MODELS:
+        raise NotImplementedError(
+            f"method='proj' Bermudan supports 1-D Lévy models {sorted(_SUPPORTED_MODELS)}; "
+            f"got model={model!r}. Use method='cos_bermudan' or method='monte_carlo'."
+        )
+
+    T = float(product.maturity)
+    ex = np.sort(np.asarray(product.exercise_times, dtype=float))
+    M = ex.size
+    # PROJ assumes a uniform monitoring grid t = dt, 2dt, ..., M*dt = T.
+    expected = np.arange(1, M + 1) * (T / M)
+    if not np.allclose(ex, expected, rtol=1e-6, atol=1e-9):
+        raise NotImplementedError(
+            "method='proj' Bermudan requires a uniform monitoring schedule "
+            "(t = dt, 2dt, ..., T); use method='cos_bermudan' for arbitrary dates."
+        )
+
+    dt = T / M
+    cf = MODEL_REGISTRY[model].cf
+    fwd_dt = ForwardSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=dt)
+    drift = (fwd.r - fwd.q) * dt
+
+    def step_cf(u):
+        return np.exp(1j * u * drift) * np.asarray(cf(u, fwd_dt, params), dtype=np.complex128)
+
+    fwd_T = ForwardSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=T)
+    grid = proj_auto_grid(MODEL_REGISTRY[model].cumulants(fwd_T, params), N=1 << 14)
+    return float(
+        proj_bermudan_put(
+            step_cf,
+            S0=fwd.S0,
+            r=fwd.r,
+            T=T,
+            W=float(product.strike),
+            M=M,
+            N=grid.N,
+            alph=grid.alph,
+        )
+    )
+
+
 def price(
     product,
     model: str,
@@ -658,6 +686,8 @@ def price(
             )
         if method == "cos_bermudan":
             return cos_bermudan_price(model, fwd, params, product, grid=grid)
+        if method == "proj":
+            return _proj_bermudan_put_price(model, fwd, params, product)
         if method == "monte_carlo":
             if model != "bsm":
                 raise NotImplementedError(
@@ -671,7 +701,8 @@ def price(
             fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
             return mc_price(fwd_t, params.sigma, product, mc_spec).price
         raise NotImplementedError(
-            "Bermudan pricing currently supports method='cos_bermudan' or method='monte_carlo'."
+            "Bermudan pricing currently supports method='cos_bermudan', method='proj' "
+            "(1-D Lévy puts), or method='monte_carlo'."
         )
 
     if pt == "barrier":
@@ -1039,26 +1070,8 @@ def price(
         fwd_t = _FwdSpec(S0=fwd.S0, r=fwd.r, q=fwd.q, T=product.maturity)
         return mc_price(fwd_t, params.sigma, product, mc_spec).price
 
-    # For future products, provide a capability hint instead of a bare NotImplementedError.
-    _HINTS: dict[str, str] = {
-        "digital": "Use method='cos_digital' or method='digital_bsm' for BSM closed form.",
-        "barrier": "Use barrier_bsm or monte_carlo for BSM barriers.",
-        "asian": "Use asian_bsm for geometric Asians or asian_mc / monte_carlo for BSM Monte Carlo.",
-        "bermudan": "Use cos_bermudan for supported 1-D Levy models or monte_carlo (BSM).",
-        "american": "Use lattice, pde_fd, or monte_carlo (Longstaff-Schwartz) for BSM Americans.",
-        "lookback": "Use lookback_bsm for continuous floating lookbacks or lookback_mc / monte_carlo for BSM Monte Carlo.",
-        "forward_start": "Use forward_start_bsm for BSM forward-start options.",
-        "variance_swap": "Use variance_analytic_bsm or variance_mc / monte_carlo for BSM variance swaps.",
-        "variance_option": (
-            "Use variance_analytic_bsm for integrated-variance options or "
-            "variance_mc / monte_carlo for realised/integrated variance options."
-        ),
-        "cliquet": "Use cliquet_mc or monte_carlo for BSM Monte Carlo cliquets.",
-        "exchange": "Use exchange_bsm for the two-asset Margrabe closed form or monte_carlo.",
-        "basket": "Use multi_asset_mc or monte_carlo for correlated multi-asset Monte Carlo.",
-        "spread": "Use spread_bsm for Kirk's approximation or multi_asset_mc / monte_carlo for Monte Carlo.",
-        "best_of": "Use multi_asset_mc or monte_carlo for correlated multi-asset Monte Carlo.",
-        "double_barrier": "Use double_barrier_mc or monte_carlo for BSM Monte Carlo double barriers.",
-    }
-    hint = _HINTS.get(pt, f"No pricer is registered for product_type={pt!r}.")
-    raise NotImplementedError(f"price(): product_type={pt!r} is not yet implemented.\n{hint}")
+    # Every supported product_type is handled by an explicit branch above; reaching
+    # here means the product_type is unknown / not yet routed.
+    raise NotImplementedError(
+        f"price(): product_type={pt!r} is not recognized or has no registered pricer."
+    )

--- a/tests/methods/test_proj_pricing.py
+++ b/tests/methods/test_proj_pricing.py
@@ -160,3 +160,44 @@ def test_proj_bermudan_dominates_european():
     )
     euro = price_strip("bsm", "proj", np.array([W]), fwd, params, cp=-1)[0]
     assert berm >= euro - 1e-6
+
+
+@pytest.mark.parametrize(
+    "model,params,tol",
+    [
+        ("bsm", fe.BsmParams(sigma=0.2), 1e-3),
+        ("vg", fe.VGParams(sigma=0.12, nu=0.2, theta=-0.14), 3e-3),
+        ("kou", fe.KouParams(sigma=0.15, lam=1.0, p=0.4, eta1=10.0, eta2=5.0), 2e-3),
+    ],
+)
+def test_price_proj_bermudan_dispatch_matches_cos(model, params, tol):
+    """The product-level price(..., method='proj') Bermudan route matches cos_bermudan."""
+    from foureng.pricers.cos_bermudan import cos_bermudan_price
+    from foureng.products.bermudan import BermudanOption
+
+    fwd = ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    M = 50
+    ex = np.arange(1, M + 1) * (1.0 / M)
+    prod = BermudanOption(strike=100.0, maturity=1.0, cp=-1, exercise_times=ex)
+
+    proj = fe.price(prod, model, "proj", fwd, params)
+    cos = cos_bermudan_price(model, fwd, params, prod)
+    assert abs(proj - cos) < tol
+
+
+def test_price_proj_bermudan_guards():
+    """PROJ Bermudan dispatch rejects calls, non-Lévy models, and non-uniform grids."""
+    from foureng.products.bermudan import BermudanOption
+
+    fwd = ForwardSpec(S0=100.0, r=0.05, q=0.0, T=1.0)
+    M = 20
+    ex = np.arange(1, M + 1) * (1.0 / M)
+    bsm = fe.BsmParams(sigma=0.2)
+
+    with pytest.raises(NotImplementedError):  # calls not supported
+        fe.price(BermudanOption(100.0, 1.0, 1, ex), "bsm", "proj", fwd, bsm)
+    with pytest.raises(NotImplementedError):  # non-Lévy model
+        heston = fe.HestonParams(kappa=2.0, theta=0.04, nu=0.3, rho=-0.6, v0=0.04)
+        fe.price(BermudanOption(100.0, 1.0, -1, ex), "heston", "proj", fwd, heston)
+    with pytest.raises(NotImplementedError):  # non-uniform schedule
+        fe.price(BermudanOption(100.0, 1.0, -1, np.array([0.3, 0.5, 1.0])), "bsm", "proj", fwd, bsm)


### PR DESCRIPTION
## Cleanup (old code)

- **Remove dead phase wrappers** — `PhaseOutputs`, `phase2_carr_madan`, `phase3_frft`, `phase4_cos` were never called anywhere and not exported (`git grep` confirms zero call sites). Their now-unused imports (`dataclass`, `CharFunc`, `FRFTGrid`) are dropped too.
- **Remove the dead `_HINTS` dict** at the end of `price()` — every `product_type` it keyed already has an explicit branch above that returns or raises first, so the dict was unreachable. Replaced with a plain `NotImplementedError`.
- **Refresh the stale `price_strip` docstring** — the model/method lists were missing `conv` / `mellin` / `proj` / `sabr_hagan` / `cos_filtered` and the non-CF baselines.

## Feature (continue PROJ parity)

- **Wire `method="proj"` into the Bermudan branch of `price()`** via a new `_proj_bermudan_put_price` helper that builds the one-step CF from the model registry and drives `proj_bermudan_put` (merged in #36 but previously unreachable through the product dispatcher). Supports the same 1-D Lévy family as `cos_bermudan`, puts on a uniform monitoring grid; **calls**, **non-Lévy models**, and **non-uniform schedules** raise `NotImplementedError` pointing to `cos_bermudan`.
- `capabilities.py`: `proj` now advertises `{european, bermudan}`.

## Validation

`price(..., "proj")` Bermudan matches `cos_bermudan` to 1e-5 (BSM/Kou) and ~1e-3 (VG); all three guard rails covered by tests. Local CI parity: ruff check + format clean, `mypy foureng` clean, full fast suite **1459 passed** at **85.13%** coverage, paper suite **296 passed**.