### PR TITLE
Fix API snapshot version visibility

### DIFF
--- a/tests/meta/test_api_snapshot.py
+++ b/tests/meta/test_api_snapshot.py
@@ -97,7 +97,7 @@ _BASELINE_API = {
 
 
 def _public(module) -> set[str]:
-    return {name for name in dir(module) if not name.startswith("_")}
+    return {name for name in dir(module) if not name.startswith("_") or name == "__version__"}
 
 
 def test_no_baseline_names_removed():


### PR DESCRIPTION
## Summary
- Include __version__ in the API snapshot helper while still filtering private names.
- Keeps the baseline public API check meaningful for the package version export.

## Verification
- ruff check foureng/ tests/
- ruff format --check foureng/ tests/
- python -m mypy foureng
- pytest -q --tb=short -m "not slow" --cov=foureng --cov-report=term-missing --cov-fail-under=70
- pytest -q --tb=short -m "paper and not slow"
- python -m build && twine check dist/*